### PR TITLE
Adds code completion

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1,902 +1,902 @@
 {
-	"name": "lfortran-lsp-client",
-	"version": "0.0.1",
-	"lockfileVersion": 2,
-	"requires": true,
-	"packages": {
-		"": {
-			"name": "lfortran-lsp-client",
-			"version": "0.0.1",
-			"license": "MIT",
-			"dependencies": {
-				"vscode-languageclient": "^7.0.0"
-			},
-			"devDependencies": {
-				"@types/vscode": "^1.63.0",
-				"@vscode/test-electron": "^2.1.2"
-			},
-			"engines": {
-				"vscode": "^1.63.0"
-			}
-		},
-		"node_modules/@tootallnate/once": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
-			"integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
-			"dev": true,
-			"engines": {
-				"node": ">= 6"
-			}
-		},
-		"node_modules/@types/vscode": {
-			"version": "1.64.0",
-			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.64.0.tgz",
-			"integrity": "sha512-bSlAWz5WtcSL3cO9tAT/KpEH9rv5OBnm93OIIFwdCshaAiqr2bp1AUyEwW9MWeCvZBHEXc3V0fTYVdVyzDNwHA==",
-			"dev": true
-		},
-		"node_modules/@vscode/test-electron": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-2.1.2.tgz",
-			"integrity": "sha512-INjJ0YA9RgR1B/xBl8P4sxww4Dy2996f4Xn5oGTFfC0c2Mm45y/1Id8xmfuoba6tR5i8zZaUIHfEYWe7Rt4uZA==",
-			"dev": true,
-			"dependencies": {
-				"http-proxy-agent": "^4.0.1",
-				"https-proxy-agent": "^5.0.0",
-				"rimraf": "^3.0.2",
-				"unzipper": "^0.10.11"
-			},
-			"engines": {
-				"node": ">=8.9.3"
-			}
-		},
-		"node_modules/@vscode/test-electron/node_modules/agent-base": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-			"integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-			"dev": true,
-			"dependencies": {
-				"debug": "4"
-			},
-			"engines": {
-				"node": ">= 6.0.0"
-			}
-		},
-		"node_modules/@vscode/test-electron/node_modules/debug": {
-			"version": "4.3.2",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-			"integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
-			"dev": true,
-			"dependencies": {
-				"ms": "2.1.2"
-			},
-			"engines": {
-				"node": ">=6.0"
-			},
-			"peerDependenciesMeta": {
-				"supports-color": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@vscode/test-electron/node_modules/http-proxy-agent": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
-			"integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
-			"dev": true,
-			"dependencies": {
-				"@tootallnate/once": "1",
-				"agent-base": "6",
-				"debug": "4"
-			},
-			"engines": {
-				"node": ">= 6"
-			}
-		},
-		"node_modules/@vscode/test-electron/node_modules/https-proxy-agent": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
-			"integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
-			"dev": true,
-			"dependencies": {
-				"agent-base": "6",
-				"debug": "4"
-			},
-			"engines": {
-				"node": ">= 6"
-			}
-		},
-		"node_modules/@vscode/test-electron/node_modules/ms": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-			"dev": true
-		},
-		"node_modules/@vscode/test-electron/node_modules/rimraf": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-			"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-			"dev": true,
-			"dependencies": {
-				"glob": "^7.1.3"
-			},
-			"bin": {
-				"rimraf": "bin.js"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/balanced-match": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
-		},
-		"node_modules/big-integer": {
-			"version": "1.6.48",
-			"resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.48.tgz",
-			"integrity": "sha512-j51egjPa7/i+RdiRuJbPdJ2FIUYYPhvYLjzoYbcMMm62ooO6F94fETG4MTs46zPAF9Brs04OajboA/qTGuz78w==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.6"
-			}
-		},
-		"node_modules/binary": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
-			"integrity": "sha1-n2BVO8XOjDOG87VTz/R0Yq3sqnk=",
-			"dev": true,
-			"dependencies": {
-				"buffers": "~0.1.1",
-				"chainsaw": "~0.1.0"
-			},
-			"engines": {
-				"node": "*"
-			}
-		},
-		"node_modules/bluebird": {
-			"version": "3.4.7",
-			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
-			"integrity": "sha1-9y12C+Cbf3bQjtj66Ysomo0F+rM=",
-			"dev": true
-		},
-		"node_modules/brace-expansion": {
-			"version": "1.1.11",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-			"dependencies": {
-				"balanced-match": "^1.0.0",
-				"concat-map": "0.0.1"
-			}
-		},
-		"node_modules/buffer-indexof-polyfill": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/buffer-indexof-polyfill/-/buffer-indexof-polyfill-1.0.2.tgz",
-			"integrity": "sha512-I7wzHwA3t1/lwXQh+A5PbNvJxgfo5r3xulgpYDB5zckTu/Z9oUK9biouBKQUjEqzaz3HnAT6TYoovmE+GqSf7A==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.10"
-			}
-		},
-		"node_modules/buffers": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
-			"integrity": "sha1-skV5w77U1tOWru5tmorn9Ugqt7s=",
-			"dev": true,
-			"engines": {
-				"node": ">=0.2.0"
-			}
-		},
-		"node_modules/chainsaw": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
-			"integrity": "sha1-XqtQsor+WAdNDVgpE4iCi15fvJg=",
-			"dev": true,
-			"dependencies": {
-				"traverse": ">=0.3.0 <0.4"
-			},
-			"engines": {
-				"node": "*"
-			}
-		},
-		"node_modules/concat-map": {
-			"version": "0.0.1",
-			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
-		},
-		"node_modules/core-util-is": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-			"dev": true
-		},
-		"node_modules/duplexer2": {
-			"version": "0.1.4",
-			"resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
-			"integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
-			"dev": true,
-			"dependencies": {
-				"readable-stream": "^2.0.2"
-			}
-		},
-		"node_modules/fs.realpath": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-			"dev": true
-		},
-		"node_modules/fstream": {
-			"version": "1.0.12",
-			"resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
-			"integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
-			"dev": true,
-			"dependencies": {
-				"graceful-fs": "^4.1.2",
-				"inherits": "~2.0.0",
-				"mkdirp": ">=0.5 0",
-				"rimraf": "2"
-			},
-			"engines": {
-				"node": ">=0.6"
-			}
-		},
-		"node_modules/glob": {
-			"version": "7.1.6",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
-			"integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
-			"dev": true,
-			"dependencies": {
-				"fs.realpath": "^1.0.0",
-				"inflight": "^1.0.4",
-				"inherits": "2",
-				"minimatch": "^3.0.4",
-				"once": "^1.3.0",
-				"path-is-absolute": "^1.0.0"
-			},
-			"engines": {
-				"node": "*"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/graceful-fs": {
-			"version": "4.2.6",
-			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
-			"integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==",
-			"dev": true
-		},
-		"node_modules/inflight": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-			"dev": true,
-			"dependencies": {
-				"once": "^1.3.0",
-				"wrappy": "1"
-			}
-		},
-		"node_modules/inherits": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-			"dev": true
-		},
-		"node_modules/isarray": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-			"dev": true
-		},
-		"node_modules/listenercount": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/listenercount/-/listenercount-1.0.1.tgz",
-			"integrity": "sha1-hMinKrWcRyUyFIDJdeZQg0LnCTc=",
-			"dev": true
-		},
-		"node_modules/lru-cache": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-			"dependencies": {
-				"yallist": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/minimatch": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-			"dependencies": {
-				"brace-expansion": "^1.1.7"
-			},
-			"engines": {
-				"node": "*"
-			}
-		},
-		"node_modules/minimist": {
-			"version": "1.2.6",
-			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-			"integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
-			"dev": true
-		},
-		"node_modules/mkdirp": {
-			"version": "0.5.5",
-			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-			"integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-			"dev": true,
-			"dependencies": {
-				"minimist": "^1.2.5"
-			},
-			"bin": {
-				"mkdirp": "bin/cmd.js"
-			}
-		},
-		"node_modules/once": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-			"dev": true,
-			"dependencies": {
-				"wrappy": "1"
-			}
-		},
-		"node_modules/path-is-absolute": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-			"dev": true,
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/process-nextick-args": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-			"dev": true
-		},
-		"node_modules/readable-stream": {
-			"version": "2.3.7",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-			"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-			"dev": true,
-			"dependencies": {
-				"core-util-is": "~1.0.0",
-				"inherits": "~2.0.3",
-				"isarray": "~1.0.0",
-				"process-nextick-args": "~2.0.0",
-				"safe-buffer": "~5.1.1",
-				"string_decoder": "~1.1.1",
-				"util-deprecate": "~1.0.1"
-			}
-		},
-		"node_modules/rimraf": {
-			"version": "2.7.1",
-			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-			"integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-			"dev": true,
-			"dependencies": {
-				"glob": "^7.1.3"
-			},
-			"bin": {
-				"rimraf": "bin.js"
-			}
-		},
-		"node_modules/safe-buffer": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-			"dev": true
-		},
-		"node_modules/semver": {
-			"version": "7.3.4",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
-			"integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
-			"dependencies": {
-				"lru-cache": "^6.0.0"
-			},
-			"bin": {
-				"semver": "bin/semver.js"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/setimmediate": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-			"integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
-			"dev": true
-		},
-		"node_modules/string_decoder": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-			"dev": true,
-			"dependencies": {
-				"safe-buffer": "~5.1.0"
-			}
-		},
-		"node_modules/traverse": {
-			"version": "0.3.9",
-			"resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
-			"integrity": "sha1-cXuPIgzAu3tE5AUUwisui7xw2Lk=",
-			"dev": true,
-			"engines": {
-				"node": "*"
-			}
-		},
-		"node_modules/unzipper": {
-			"version": "0.10.11",
-			"resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.10.11.tgz",
-			"integrity": "sha512-+BrAq2oFqWod5IESRjL3S8baohbevGcVA+teAIOYWM3pDVdseogqbzhhvvmiyQrUNKFUnDMtELW3X8ykbyDCJw==",
-			"dev": true,
-			"dependencies": {
-				"big-integer": "^1.6.17",
-				"binary": "~0.3.0",
-				"bluebird": "~3.4.1",
-				"buffer-indexof-polyfill": "~1.0.0",
-				"duplexer2": "~0.1.4",
-				"fstream": "^1.0.12",
-				"graceful-fs": "^4.2.2",
-				"listenercount": "~1.0.1",
-				"readable-stream": "~2.3.6",
-				"setimmediate": "~1.0.4"
-			}
-		},
-		"node_modules/util-deprecate": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-			"dev": true
-		},
-		"node_modules/vscode-jsonrpc": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-6.0.0.tgz",
-			"integrity": "sha512-wnJA4BnEjOSyFMvjZdpiOwhSq9uDoK8e/kpRJDTaMYzwlkrhG1fwDIZI94CLsLzlCK5cIbMMtFlJlfR57Lavmg==",
-			"engines": {
-				"node": ">=8.0.0 || >=10.0.0"
-			}
-		},
-		"node_modules/vscode-languageclient": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-7.0.0.tgz",
-			"integrity": "sha512-P9AXdAPlsCgslpP9pRxYPqkNYV7Xq8300/aZDpO35j1fJm/ncize8iGswzYlcvFw5DQUx4eVk+KvfXdL0rehNg==",
-			"dependencies": {
-				"minimatch": "^3.0.4",
-				"semver": "^7.3.4",
-				"vscode-languageserver-protocol": "3.16.0"
-			},
-			"engines": {
-				"vscode": "^1.52.0"
-			}
-		},
-		"node_modules/vscode-languageserver-protocol": {
-			"version": "3.16.0",
-			"resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.16.0.tgz",
-			"integrity": "sha512-sdeUoAawceQdgIfTI+sdcwkiK2KU+2cbEYA0agzM2uqaUy2UpnnGHtWTHVEtS0ES4zHU0eMFRGN+oQgDxlD66A==",
-			"dependencies": {
-				"vscode-jsonrpc": "6.0.0",
-				"vscode-languageserver-types": "3.16.0"
-			}
-		},
-		"node_modules/vscode-languageserver-types": {
-			"version": "3.16.0",
-			"resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0.tgz",
-			"integrity": "sha512-k8luDIWJWyenLc5ToFQQMaSrqCHiLwyKPHKPQZ5zz21vM+vIVUSvsRpcbiECH4WR88K2XZqc4ScRcZ7nk/jbeA=="
-		},
-		"node_modules/wrappy": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-			"dev": true
-		},
-		"node_modules/yallist": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
-		}
-	},
-	"dependencies": {
-		"@tootallnate/once": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
-			"integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
-			"dev": true
-		},
-		"@types/vscode": {
-			"version": "1.64.0",
-			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.64.0.tgz",
-			"integrity": "sha512-bSlAWz5WtcSL3cO9tAT/KpEH9rv5OBnm93OIIFwdCshaAiqr2bp1AUyEwW9MWeCvZBHEXc3V0fTYVdVyzDNwHA==",
-			"dev": true
-		},
-		"@vscode/test-electron": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-2.1.2.tgz",
-			"integrity": "sha512-INjJ0YA9RgR1B/xBl8P4sxww4Dy2996f4Xn5oGTFfC0c2Mm45y/1Id8xmfuoba6tR5i8zZaUIHfEYWe7Rt4uZA==",
-			"dev": true,
-			"requires": {
-				"http-proxy-agent": "^4.0.1",
-				"https-proxy-agent": "^5.0.0",
-				"rimraf": "^3.0.2",
-				"unzipper": "^0.10.11"
-			},
-			"dependencies": {
-				"agent-base": {
-					"version": "6.0.2",
-					"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-					"integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-					"dev": true,
-					"requires": {
-						"debug": "4"
-					}
-				},
-				"debug": {
-					"version": "4.3.2",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-					"integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
-					"dev": true,
-					"requires": {
-						"ms": "2.1.2"
-					}
-				},
-				"http-proxy-agent": {
-					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
-					"integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
-					"dev": true,
-					"requires": {
-						"@tootallnate/once": "1",
-						"agent-base": "6",
-						"debug": "4"
-					}
-				},
-				"https-proxy-agent": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
-					"integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
-					"dev": true,
-					"requires": {
-						"agent-base": "6",
-						"debug": "4"
-					}
-				},
-				"ms": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-					"dev": true
-				},
-				"rimraf": {
-					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-					"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-					"dev": true,
-					"requires": {
-						"glob": "^7.1.3"
-					}
-				}
-			}
-		},
-		"balanced-match": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
-		},
-		"big-integer": {
-			"version": "1.6.48",
-			"resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.48.tgz",
-			"integrity": "sha512-j51egjPa7/i+RdiRuJbPdJ2FIUYYPhvYLjzoYbcMMm62ooO6F94fETG4MTs46zPAF9Brs04OajboA/qTGuz78w==",
-			"dev": true
-		},
-		"binary": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
-			"integrity": "sha1-n2BVO8XOjDOG87VTz/R0Yq3sqnk=",
-			"dev": true,
-			"requires": {
-				"buffers": "~0.1.1",
-				"chainsaw": "~0.1.0"
-			}
-		},
-		"bluebird": {
-			"version": "3.4.7",
-			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
-			"integrity": "sha1-9y12C+Cbf3bQjtj66Ysomo0F+rM=",
-			"dev": true
-		},
-		"brace-expansion": {
-			"version": "1.1.11",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-			"requires": {
-				"balanced-match": "^1.0.0",
-				"concat-map": "0.0.1"
-			}
-		},
-		"buffer-indexof-polyfill": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/buffer-indexof-polyfill/-/buffer-indexof-polyfill-1.0.2.tgz",
-			"integrity": "sha512-I7wzHwA3t1/lwXQh+A5PbNvJxgfo5r3xulgpYDB5zckTu/Z9oUK9biouBKQUjEqzaz3HnAT6TYoovmE+GqSf7A==",
-			"dev": true
-		},
-		"buffers": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
-			"integrity": "sha1-skV5w77U1tOWru5tmorn9Ugqt7s=",
-			"dev": true
-		},
-		"chainsaw": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
-			"integrity": "sha1-XqtQsor+WAdNDVgpE4iCi15fvJg=",
-			"dev": true,
-			"requires": {
-				"traverse": ">=0.3.0 <0.4"
-			}
-		},
-		"concat-map": {
-			"version": "0.0.1",
-			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
-		},
-		"core-util-is": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-			"dev": true
-		},
-		"duplexer2": {
-			"version": "0.1.4",
-			"resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
-			"integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
-			"dev": true,
-			"requires": {
-				"readable-stream": "^2.0.2"
-			}
-		},
-		"fs.realpath": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-			"dev": true
-		},
-		"fstream": {
-			"version": "1.0.12",
-			"resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
-			"integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
-			"dev": true,
-			"requires": {
-				"graceful-fs": "^4.1.2",
-				"inherits": "~2.0.0",
-				"mkdirp": ">=0.5 0",
-				"rimraf": "2"
-			}
-		},
-		"glob": {
-			"version": "7.1.6",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
-			"integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
-			"dev": true,
-			"requires": {
-				"fs.realpath": "^1.0.0",
-				"inflight": "^1.0.4",
-				"inherits": "2",
-				"minimatch": "^3.0.4",
-				"once": "^1.3.0",
-				"path-is-absolute": "^1.0.0"
-			}
-		},
-		"graceful-fs": {
-			"version": "4.2.6",
-			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
-			"integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==",
-			"dev": true
-		},
-		"inflight": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-			"dev": true,
-			"requires": {
-				"once": "^1.3.0",
-				"wrappy": "1"
-			}
-		},
-		"inherits": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-			"dev": true
-		},
-		"isarray": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-			"dev": true
-		},
-		"listenercount": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/listenercount/-/listenercount-1.0.1.tgz",
-			"integrity": "sha1-hMinKrWcRyUyFIDJdeZQg0LnCTc=",
-			"dev": true
-		},
-		"lru-cache": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-			"requires": {
-				"yallist": "^4.0.0"
-			}
-		},
-		"minimatch": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-			"requires": {
-				"brace-expansion": "^1.1.7"
-			}
-		},
-		"minimist": {
-			"version": "1.2.6",
-			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-			"integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
-			"dev": true
-		},
-		"mkdirp": {
-			"version": "0.5.5",
-			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-			"integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-			"dev": true,
-			"requires": {
-				"minimist": "^1.2.5"
-			}
-		},
-		"once": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-			"dev": true,
-			"requires": {
-				"wrappy": "1"
-			}
-		},
-		"path-is-absolute": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-			"dev": true
-		},
-		"process-nextick-args": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-			"dev": true
-		},
-		"readable-stream": {
-			"version": "2.3.7",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-			"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-			"dev": true,
-			"requires": {
-				"core-util-is": "~1.0.0",
-				"inherits": "~2.0.3",
-				"isarray": "~1.0.0",
-				"process-nextick-args": "~2.0.0",
-				"safe-buffer": "~5.1.1",
-				"string_decoder": "~1.1.1",
-				"util-deprecate": "~1.0.1"
-			}
-		},
-		"rimraf": {
-			"version": "2.7.1",
-			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-			"integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-			"dev": true,
-			"requires": {
-				"glob": "^7.1.3"
-			}
-		},
-		"safe-buffer": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-			"dev": true
-		},
-		"semver": {
-			"version": "7.3.4",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
-			"integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
-			"requires": {
-				"lru-cache": "^6.0.0"
-			}
-		},
-		"setimmediate": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-			"integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
-			"dev": true
-		},
-		"string_decoder": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-			"dev": true,
-			"requires": {
-				"safe-buffer": "~5.1.0"
-			}
-		},
-		"traverse": {
-			"version": "0.3.9",
-			"resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
-			"integrity": "sha1-cXuPIgzAu3tE5AUUwisui7xw2Lk=",
-			"dev": true
-		},
-		"unzipper": {
-			"version": "0.10.11",
-			"resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.10.11.tgz",
-			"integrity": "sha512-+BrAq2oFqWod5IESRjL3S8baohbevGcVA+teAIOYWM3pDVdseogqbzhhvvmiyQrUNKFUnDMtELW3X8ykbyDCJw==",
-			"dev": true,
-			"requires": {
-				"big-integer": "^1.6.17",
-				"binary": "~0.3.0",
-				"bluebird": "~3.4.1",
-				"buffer-indexof-polyfill": "~1.0.0",
-				"duplexer2": "~0.1.4",
-				"fstream": "^1.0.12",
-				"graceful-fs": "^4.2.2",
-				"listenercount": "~1.0.1",
-				"readable-stream": "~2.3.6",
-				"setimmediate": "~1.0.4"
-			}
-		},
-		"util-deprecate": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-			"dev": true
-		},
-		"vscode-jsonrpc": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-6.0.0.tgz",
-			"integrity": "sha512-wnJA4BnEjOSyFMvjZdpiOwhSq9uDoK8e/kpRJDTaMYzwlkrhG1fwDIZI94CLsLzlCK5cIbMMtFlJlfR57Lavmg=="
-		},
-		"vscode-languageclient": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-7.0.0.tgz",
-			"integrity": "sha512-P9AXdAPlsCgslpP9pRxYPqkNYV7Xq8300/aZDpO35j1fJm/ncize8iGswzYlcvFw5DQUx4eVk+KvfXdL0rehNg==",
-			"requires": {
-				"minimatch": "^3.0.4",
-				"semver": "^7.3.4",
-				"vscode-languageserver-protocol": "3.16.0"
-			}
-		},
-		"vscode-languageserver-protocol": {
-			"version": "3.16.0",
-			"resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.16.0.tgz",
-			"integrity": "sha512-sdeUoAawceQdgIfTI+sdcwkiK2KU+2cbEYA0agzM2uqaUy2UpnnGHtWTHVEtS0ES4zHU0eMFRGN+oQgDxlD66A==",
-			"requires": {
-				"vscode-jsonrpc": "6.0.0",
-				"vscode-languageserver-types": "3.16.0"
-			}
-		},
-		"vscode-languageserver-types": {
-			"version": "3.16.0",
-			"resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0.tgz",
-			"integrity": "sha512-k8luDIWJWyenLc5ToFQQMaSrqCHiLwyKPHKPQZ5zz21vM+vIVUSvsRpcbiECH4WR88K2XZqc4ScRcZ7nk/jbeA=="
-		},
-		"wrappy": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-			"dev": true
-		},
-		"yallist": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
-		}
-	}
+  "name": "lfortran-lsp-client",
+  "version": "1.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "lfortran-lsp-client",
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "vscode-languageclient": "^7.0.0"
+      },
+      "devDependencies": {
+        "@types/vscode": "^1.63.0",
+        "@vscode/test-electron": "^2.1.2"
+      },
+      "engines": {
+        "vscode": "^1.63.0"
+      }
+    },
+    "node_modules/@tootallnate/once": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
+      "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/@types/vscode": {
+      "version": "1.64.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.64.0.tgz",
+      "integrity": "sha512-bSlAWz5WtcSL3cO9tAT/KpEH9rv5OBnm93OIIFwdCshaAiqr2bp1AUyEwW9MWeCvZBHEXc3V0fTYVdVyzDNwHA==",
+      "dev": true
+    },
+    "node_modules/@vscode/test-electron": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-2.1.2.tgz",
+      "integrity": "sha512-INjJ0YA9RgR1B/xBl8P4sxww4Dy2996f4Xn5oGTFfC0c2Mm45y/1Id8xmfuoba6tR5i8zZaUIHfEYWe7Rt4uZA==",
+      "dev": true,
+      "dependencies": {
+        "http-proxy-agent": "^4.0.1",
+        "https-proxy-agent": "^5.0.0",
+        "rimraf": "^3.0.2",
+        "unzipper": "^0.10.11"
+      },
+      "engines": {
+        "node": ">=8.9.3"
+      }
+    },
+    "node_modules/@vscode/test-electron/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dev": true,
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/@vscode/test-electron/node_modules/debug": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+      "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vscode/test-electron/node_modules/http-proxy-agent": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
+      "integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
+      "dev": true,
+      "dependencies": {
+        "@tootallnate/once": "1",
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/@vscode/test-electron/node_modules/https-proxy-agent": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
+      "dev": true,
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/@vscode/test-electron/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
+    },
+    "node_modules/@vscode/test-electron/node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "dev": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+    },
+    "node_modules/big-integer": {
+      "version": "1.6.48",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.48.tgz",
+      "integrity": "sha512-j51egjPa7/i+RdiRuJbPdJ2FIUYYPhvYLjzoYbcMMm62ooO6F94fETG4MTs46zPAF9Brs04OajboA/qTGuz78w==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/binary": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
+      "integrity": "sha1-n2BVO8XOjDOG87VTz/R0Yq3sqnk=",
+      "dev": true,
+      "dependencies": {
+        "buffers": "~0.1.1",
+        "chainsaw": "~0.1.0"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/bluebird": {
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
+      "integrity": "sha1-9y12C+Cbf3bQjtj66Ysomo0F+rM=",
+      "dev": true
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/buffer-indexof-polyfill": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/buffer-indexof-polyfill/-/buffer-indexof-polyfill-1.0.2.tgz",
+      "integrity": "sha512-I7wzHwA3t1/lwXQh+A5PbNvJxgfo5r3xulgpYDB5zckTu/Z9oUK9biouBKQUjEqzaz3HnAT6TYoovmE+GqSf7A==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/buffers": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
+      "integrity": "sha1-skV5w77U1tOWru5tmorn9Ugqt7s=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.2.0"
+      }
+    },
+    "node_modules/chainsaw": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
+      "integrity": "sha1-XqtQsor+WAdNDVgpE4iCi15fvJg=",
+      "dev": true,
+      "dependencies": {
+        "traverse": ">=0.3.0 <0.4"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
+    },
+    "node_modules/duplexer2": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
+      "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
+      "dev": true,
+      "dependencies": {
+        "readable-stream": "^2.0.2"
+      }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "node_modules/fstream": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
+      "integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "inherits": "~2.0.0",
+        "mkdirp": ">=0.5 0",
+        "rimraf": "2"
+      },
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/glob": {
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
+      "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==",
+      "dev": true
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
+    },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
+    },
+    "node_modules/listenercount": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/listenercount/-/listenercount-1.0.1.tgz",
+      "integrity": "sha1-hMinKrWcRyUyFIDJdeZQg0LnCTc=",
+      "dev": true
+    },
+    "node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
+      "dev": true
+    },
+    "node_modules/mkdirp": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+      "dev": true,
+      "dependencies": {
+        "minimist": "^1.2.5"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true
+    },
+    "node_modules/readable-stream": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+      "dev": true,
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/rimraf": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+      "dev": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
+    },
+    "node_modules/semver": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
+      "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
+      "dev": true
+    },
+    "node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/traverse": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
+      "integrity": "sha1-cXuPIgzAu3tE5AUUwisui7xw2Lk=",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/unzipper": {
+      "version": "0.10.11",
+      "resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.10.11.tgz",
+      "integrity": "sha512-+BrAq2oFqWod5IESRjL3S8baohbevGcVA+teAIOYWM3pDVdseogqbzhhvvmiyQrUNKFUnDMtELW3X8ykbyDCJw==",
+      "dev": true,
+      "dependencies": {
+        "big-integer": "^1.6.17",
+        "binary": "~0.3.0",
+        "bluebird": "~3.4.1",
+        "buffer-indexof-polyfill": "~1.0.0",
+        "duplexer2": "~0.1.4",
+        "fstream": "^1.0.12",
+        "graceful-fs": "^4.2.2",
+        "listenercount": "~1.0.1",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "~1.0.4"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
+    },
+    "node_modules/vscode-jsonrpc": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-6.0.0.tgz",
+      "integrity": "sha512-wnJA4BnEjOSyFMvjZdpiOwhSq9uDoK8e/kpRJDTaMYzwlkrhG1fwDIZI94CLsLzlCK5cIbMMtFlJlfR57Lavmg==",
+      "engines": {
+        "node": ">=8.0.0 || >=10.0.0"
+      }
+    },
+    "node_modules/vscode-languageclient": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-7.0.0.tgz",
+      "integrity": "sha512-P9AXdAPlsCgslpP9pRxYPqkNYV7Xq8300/aZDpO35j1fJm/ncize8iGswzYlcvFw5DQUx4eVk+KvfXdL0rehNg==",
+      "dependencies": {
+        "minimatch": "^3.0.4",
+        "semver": "^7.3.4",
+        "vscode-languageserver-protocol": "3.16.0"
+      },
+      "engines": {
+        "vscode": "^1.52.0"
+      }
+    },
+    "node_modules/vscode-languageserver-protocol": {
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.16.0.tgz",
+      "integrity": "sha512-sdeUoAawceQdgIfTI+sdcwkiK2KU+2cbEYA0agzM2uqaUy2UpnnGHtWTHVEtS0ES4zHU0eMFRGN+oQgDxlD66A==",
+      "dependencies": {
+        "vscode-jsonrpc": "6.0.0",
+        "vscode-languageserver-types": "3.16.0"
+      }
+    },
+    "node_modules/vscode-languageserver-types": {
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0.tgz",
+      "integrity": "sha512-k8luDIWJWyenLc5ToFQQMaSrqCHiLwyKPHKPQZ5zz21vM+vIVUSvsRpcbiECH4WR88K2XZqc4ScRcZ7nk/jbeA=="
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    },
+    "node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+    }
+  },
+  "dependencies": {
+    "@tootallnate/once": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
+      "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
+      "dev": true
+    },
+    "@types/vscode": {
+      "version": "1.64.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.64.0.tgz",
+      "integrity": "sha512-bSlAWz5WtcSL3cO9tAT/KpEH9rv5OBnm93OIIFwdCshaAiqr2bp1AUyEwW9MWeCvZBHEXc3V0fTYVdVyzDNwHA==",
+      "dev": true
+    },
+    "@vscode/test-electron": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-2.1.2.tgz",
+      "integrity": "sha512-INjJ0YA9RgR1B/xBl8P4sxww4Dy2996f4Xn5oGTFfC0c2Mm45y/1Id8xmfuoba6tR5i8zZaUIHfEYWe7Rt4uZA==",
+      "dev": true,
+      "requires": {
+        "http-proxy-agent": "^4.0.1",
+        "https-proxy-agent": "^5.0.0",
+        "rimraf": "^3.0.2",
+        "unzipper": "^0.10.11"
+      },
+      "dependencies": {
+        "agent-base": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+          "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+          "dev": true,
+          "requires": {
+            "debug": "4"
+          }
+        },
+        "debug": {
+          "version": "4.3.2",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+          "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "http-proxy-agent": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
+          "integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
+          "dev": true,
+          "requires": {
+            "@tootallnate/once": "1",
+            "agent-base": "6",
+            "debug": "4"
+          }
+        },
+        "https-proxy-agent": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
+          "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
+          "dev": true,
+          "requires": {
+            "agent-base": "6",
+            "debug": "4"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        },
+        "rimraf": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
+      }
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+    },
+    "big-integer": {
+      "version": "1.6.48",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.48.tgz",
+      "integrity": "sha512-j51egjPa7/i+RdiRuJbPdJ2FIUYYPhvYLjzoYbcMMm62ooO6F94fETG4MTs46zPAF9Brs04OajboA/qTGuz78w==",
+      "dev": true
+    },
+    "binary": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
+      "integrity": "sha1-n2BVO8XOjDOG87VTz/R0Yq3sqnk=",
+      "dev": true,
+      "requires": {
+        "buffers": "~0.1.1",
+        "chainsaw": "~0.1.0"
+      }
+    },
+    "bluebird": {
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
+      "integrity": "sha1-9y12C+Cbf3bQjtj66Ysomo0F+rM=",
+      "dev": true
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "buffer-indexof-polyfill": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/buffer-indexof-polyfill/-/buffer-indexof-polyfill-1.0.2.tgz",
+      "integrity": "sha512-I7wzHwA3t1/lwXQh+A5PbNvJxgfo5r3xulgpYDB5zckTu/Z9oUK9biouBKQUjEqzaz3HnAT6TYoovmE+GqSf7A==",
+      "dev": true
+    },
+    "buffers": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
+      "integrity": "sha1-skV5w77U1tOWru5tmorn9Ugqt7s=",
+      "dev": true
+    },
+    "chainsaw": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
+      "integrity": "sha1-XqtQsor+WAdNDVgpE4iCi15fvJg=",
+      "dev": true,
+      "requires": {
+        "traverse": ">=0.3.0 <0.4"
+      }
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
+    },
+    "duplexer2": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
+      "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
+      "dev": true,
+      "requires": {
+        "readable-stream": "^2.0.2"
+      }
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "fstream": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
+      "integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "inherits": "~2.0.0",
+        "mkdirp": ">=0.5 0",
+        "rimraf": "2"
+      }
+    },
+    "glob": {
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
+    "graceful-fs": {
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
+      "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==",
+      "dev": true
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
+    },
+    "listenercount": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/listenercount/-/listenercount-1.0.1.tgz",
+      "integrity": "sha1-hMinKrWcRyUyFIDJdeZQg0LnCTc=",
+      "dev": true
+    },
+    "lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "requires": {
+        "yallist": "^4.0.0"
+      }
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
+    },
+    "minimist": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
+      "dev": true
+    },
+    "mkdirp": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+      "dev": true,
+      "requires": {
+        "minimist": "^1.2.5"
+      }
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true
+    },
+    "readable-stream": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+      "dev": true,
+      "requires": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "rimraf": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.1.3"
+      }
+    },
+    "safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
+    },
+    "semver": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
+      "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
+      "requires": {
+        "lru-cache": "^6.0.0"
+      }
+    },
+    "setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
+      "dev": true
+    },
+    "string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "traverse": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
+      "integrity": "sha1-cXuPIgzAu3tE5AUUwisui7xw2Lk=",
+      "dev": true
+    },
+    "unzipper": {
+      "version": "0.10.11",
+      "resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.10.11.tgz",
+      "integrity": "sha512-+BrAq2oFqWod5IESRjL3S8baohbevGcVA+teAIOYWM3pDVdseogqbzhhvvmiyQrUNKFUnDMtELW3X8ykbyDCJw==",
+      "dev": true,
+      "requires": {
+        "big-integer": "^1.6.17",
+        "binary": "~0.3.0",
+        "bluebird": "~3.4.1",
+        "buffer-indexof-polyfill": "~1.0.0",
+        "duplexer2": "~0.1.4",
+        "fstream": "^1.0.12",
+        "graceful-fs": "^4.2.2",
+        "listenercount": "~1.0.1",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "~1.0.4"
+      }
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
+    },
+    "vscode-jsonrpc": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-6.0.0.tgz",
+      "integrity": "sha512-wnJA4BnEjOSyFMvjZdpiOwhSq9uDoK8e/kpRJDTaMYzwlkrhG1fwDIZI94CLsLzlCK5cIbMMtFlJlfR57Lavmg=="
+    },
+    "vscode-languageclient": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-7.0.0.tgz",
+      "integrity": "sha512-P9AXdAPlsCgslpP9pRxYPqkNYV7Xq8300/aZDpO35j1fJm/ncize8iGswzYlcvFw5DQUx4eVk+KvfXdL0rehNg==",
+      "requires": {
+        "minimatch": "^3.0.4",
+        "semver": "^7.3.4",
+        "vscode-languageserver-protocol": "3.16.0"
+      }
+    },
+    "vscode-languageserver-protocol": {
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.16.0.tgz",
+      "integrity": "sha512-sdeUoAawceQdgIfTI+sdcwkiK2KU+2cbEYA0agzM2uqaUy2UpnnGHtWTHVEtS0ES4zHU0eMFRGN+oQgDxlD66A==",
+      "requires": {
+        "vscode-jsonrpc": "6.0.0",
+        "vscode-languageserver-types": "3.16.0"
+      }
+    },
+    "vscode-languageserver-types": {
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0.tgz",
+      "integrity": "sha512-k8luDIWJWyenLc5ToFQQMaSrqCHiLwyKPHKPQZ5zz21vM+vIVUSvsRpcbiECH4WR88K2XZqc4ScRcZ7nk/jbeA=="
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    },
+    "yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+    }
+  }
 }

--- a/client/package.json
+++ b/client/package.json
@@ -1,22 +1,22 @@
 {
-	"name": "lfortran-lsp-client",
-	"description": "LFortran LSP client.",
-	"author": "LCompilers",
-	"license": "MIT",
-	"version": "1.0.0",
+  "name": "lfortran-lsp-client",
+  "description": "LFortran LSP client.",
+  "author": "LCompilers",
+  "license": "MIT",
+  "version": "1.0.0",
   "publisher": "LCompilers",
-	"repository": {
-		"type": "git",
-		"url": "https://github.com/dylon/lfortran-lsp"
-	},
-	"engines": {
-		"vscode": "^1.63.0"
-	},
-	"dependencies": {
-		"vscode-languageclient": "^7.0.0"
-	},
-	"devDependencies": {
-		"@types/vscode": "^1.63.0",
-		"@vscode/test-electron": "^2.1.2"
-	}
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/dylon/lfortran-lsp"
+  },
+  "engines": {
+    "vscode": "^1.63.0"
+  },
+  "dependencies": {
+    "vscode-languageclient": "^7.0.0"
+  },
+  "devDependencies": {
+    "@types/vscode": "^1.63.0",
+    "@vscode/test-electron": "^2.1.2"
+  }
 }

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -23,7 +23,7 @@ export function activate(context: ExtensionContext) {
 
   // The server is implemented in node
   const serverModule = context.asAbsolutePath(
-    path.join('out', 'server', 'src', 'server.js')
+    path.join('out', 'server', 'src', 'main.js')
   );
 
   // The debug options for the server

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     ],
     "configuration": {
       "type": "object",
-      "title": "Example configuration",
+      "title": "LFortran Language Server",
       "properties": {
         "LFortranLanguageServer.maxNumberOfProblems": {
           "scope": "resource",

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,107 +1,145 @@
 {
-	"name": "lfortran-lsp-server",
-	"version": "1.0.0",
-	"lockfileVersion": 2,
-	"requires": true,
-	"packages": {
-		"": {
-			"name": "lfortran-lsp-server",
-			"version": "1.0.0",
-			"license": "MIT",
-			"dependencies": {
-				"vscode-languageserver": "^7.0.0",
-				"vscode-languageserver-textdocument": "^1.0.4"
-			},
-			"devDependencies": {
-				"@types/tmp": "^0.2.3"
-			},
-			"engines": {
-				"node": "*"
-			}
-		},
-		"node_modules/@types/tmp": {
-			"version": "0.2.3",
-			"resolved": "https://registry.npmjs.org/@types/tmp/-/tmp-0.2.3.tgz",
-			"integrity": "sha512-dDZH/tXzwjutnuk4UacGgFRwV+JSLaXL1ikvidfJprkb7L9Nx1njcRHHmi3Dsvt7pgqqTEeucQuOrWHPFgzVHA==",
-			"dev": true
-		},
-		"node_modules/vscode-jsonrpc": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-6.0.0.tgz",
-			"integrity": "sha512-wnJA4BnEjOSyFMvjZdpiOwhSq9uDoK8e/kpRJDTaMYzwlkrhG1fwDIZI94CLsLzlCK5cIbMMtFlJlfR57Lavmg==",
-			"engines": {
-				"node": ">=8.0.0 || >=10.0.0"
-			}
-		},
-		"node_modules/vscode-languageserver": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-7.0.0.tgz",
-			"integrity": "sha512-60HTx5ID+fLRcgdHfmz0LDZAXYEV68fzwG0JWwEPBode9NuMYTIxuYXPg4ngO8i8+Ou0lM7y6GzaYWbiDL0drw==",
-			"dependencies": {
-				"vscode-languageserver-protocol": "3.16.0"
-			},
-			"bin": {
-				"installServerIntoExtension": "bin/installServerIntoExtension"
-			}
-		},
-		"node_modules/vscode-languageserver-protocol": {
-			"version": "3.16.0",
-			"resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.16.0.tgz",
-			"integrity": "sha512-sdeUoAawceQdgIfTI+sdcwkiK2KU+2cbEYA0agzM2uqaUy2UpnnGHtWTHVEtS0ES4zHU0eMFRGN+oQgDxlD66A==",
-			"dependencies": {
-				"vscode-jsonrpc": "6.0.0",
-				"vscode-languageserver-types": "3.16.0"
-			}
-		},
-		"node_modules/vscode-languageserver-textdocument": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.4.tgz",
-			"integrity": "sha512-/xhqXP/2A2RSs+J8JNXpiiNVvvNM0oTosNVmQnunlKvq9o4mupHOBAnnzH0lwIPKazXKvAKsVp1kr+H/K4lgoQ=="
-		},
-		"node_modules/vscode-languageserver-types": {
-			"version": "3.16.0",
-			"resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0.tgz",
-			"integrity": "sha512-k8luDIWJWyenLc5ToFQQMaSrqCHiLwyKPHKPQZ5zz21vM+vIVUSvsRpcbiECH4WR88K2XZqc4ScRcZ7nk/jbeA=="
-		}
-	},
-	"dependencies": {
-		"@types/tmp": {
-			"version": "0.2.3",
-			"resolved": "https://registry.npmjs.org/@types/tmp/-/tmp-0.2.3.tgz",
-			"integrity": "sha512-dDZH/tXzwjutnuk4UacGgFRwV+JSLaXL1ikvidfJprkb7L9Nx1njcRHHmi3Dsvt7pgqqTEeucQuOrWHPFgzVHA==",
-			"dev": true
-		},
-		"vscode-jsonrpc": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-6.0.0.tgz",
-			"integrity": "sha512-wnJA4BnEjOSyFMvjZdpiOwhSq9uDoK8e/kpRJDTaMYzwlkrhG1fwDIZI94CLsLzlCK5cIbMMtFlJlfR57Lavmg=="
-		},
-		"vscode-languageserver": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-7.0.0.tgz",
-			"integrity": "sha512-60HTx5ID+fLRcgdHfmz0LDZAXYEV68fzwG0JWwEPBode9NuMYTIxuYXPg4ngO8i8+Ou0lM7y6GzaYWbiDL0drw==",
-			"requires": {
-				"vscode-languageserver-protocol": "3.16.0"
-			}
-		},
-		"vscode-languageserver-protocol": {
-			"version": "3.16.0",
-			"resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.16.0.tgz",
-			"integrity": "sha512-sdeUoAawceQdgIfTI+sdcwkiK2KU+2cbEYA0agzM2uqaUy2UpnnGHtWTHVEtS0ES4zHU0eMFRGN+oQgDxlD66A==",
-			"requires": {
-				"vscode-jsonrpc": "6.0.0",
-				"vscode-languageserver-types": "3.16.0"
-			}
-		},
-		"vscode-languageserver-textdocument": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.4.tgz",
-			"integrity": "sha512-/xhqXP/2A2RSs+J8JNXpiiNVvvNM0oTosNVmQnunlKvq9o4mupHOBAnnzH0lwIPKazXKvAKsVp1kr+H/K4lgoQ=="
-		},
-		"vscode-languageserver-types": {
-			"version": "3.16.0",
-			"resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0.tgz",
-			"integrity": "sha512-k8luDIWJWyenLc5ToFQQMaSrqCHiLwyKPHKPQZ5zz21vM+vIVUSvsRpcbiECH4WR88K2XZqc4ScRcZ7nk/jbeA=="
-		}
-	}
+  "name": "lfortran-lsp-server",
+  "version": "1.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "lfortran-lsp-server",
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "vscode-languageserver": "^7.0.0",
+        "vscode-languageserver-textdocument": "^1.0.4",
+        "which": "5.0.0"
+      },
+      "devDependencies": {
+        "@types/tmp": "^0.2.3"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@types/tmp": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@types/tmp/-/tmp-0.2.3.tgz",
+      "integrity": "sha512-dDZH/tXzwjutnuk4UacGgFRwV+JSLaXL1ikvidfJprkb7L9Nx1njcRHHmi3Dsvt7pgqqTEeucQuOrWHPFgzVHA==",
+      "dev": true
+    },
+    "node_modules/isexe": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.1.tgz",
+      "integrity": "sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/vscode-jsonrpc": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-6.0.0.tgz",
+      "integrity": "sha512-wnJA4BnEjOSyFMvjZdpiOwhSq9uDoK8e/kpRJDTaMYzwlkrhG1fwDIZI94CLsLzlCK5cIbMMtFlJlfR57Lavmg==",
+      "engines": {
+        "node": ">=8.0.0 || >=10.0.0"
+      }
+    },
+    "node_modules/vscode-languageserver": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-7.0.0.tgz",
+      "integrity": "sha512-60HTx5ID+fLRcgdHfmz0LDZAXYEV68fzwG0JWwEPBode9NuMYTIxuYXPg4ngO8i8+Ou0lM7y6GzaYWbiDL0drw==",
+      "dependencies": {
+        "vscode-languageserver-protocol": "3.16.0"
+      },
+      "bin": {
+        "installServerIntoExtension": "bin/installServerIntoExtension"
+      }
+    },
+    "node_modules/vscode-languageserver-protocol": {
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.16.0.tgz",
+      "integrity": "sha512-sdeUoAawceQdgIfTI+sdcwkiK2KU+2cbEYA0agzM2uqaUy2UpnnGHtWTHVEtS0ES4zHU0eMFRGN+oQgDxlD66A==",
+      "dependencies": {
+        "vscode-jsonrpc": "6.0.0",
+        "vscode-languageserver-types": "3.16.0"
+      }
+    },
+    "node_modules/vscode-languageserver-textdocument": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.4.tgz",
+      "integrity": "sha512-/xhqXP/2A2RSs+J8JNXpiiNVvvNM0oTosNVmQnunlKvq9o4mupHOBAnnzH0lwIPKazXKvAKsVp1kr+H/K4lgoQ=="
+    },
+    "node_modules/vscode-languageserver-types": {
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0.tgz",
+      "integrity": "sha512-k8luDIWJWyenLc5ToFQQMaSrqCHiLwyKPHKPQZ5zz21vM+vIVUSvsRpcbiECH4WR88K2XZqc4ScRcZ7nk/jbeA=="
+    },
+    "node_modules/which": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/which/-/which-5.0.0.tgz",
+      "integrity": "sha512-JEdGzHwwkrbWoGOlIHqQ5gtprKGOenpDHpxE9zVR1bWbOtYRyPPHMe9FaP6x61CmNaTThSkb0DAJte5jD+DmzQ==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^3.1.1"
+      },
+      "bin": {
+        "node-which": "bin/which.js"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    }
+  },
+  "dependencies": {
+    "@types/tmp": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@types/tmp/-/tmp-0.2.3.tgz",
+      "integrity": "sha512-dDZH/tXzwjutnuk4UacGgFRwV+JSLaXL1ikvidfJprkb7L9Nx1njcRHHmi3Dsvt7pgqqTEeucQuOrWHPFgzVHA==",
+      "dev": true
+    },
+    "isexe": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.1.tgz",
+      "integrity": "sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ=="
+    },
+    "vscode-jsonrpc": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-6.0.0.tgz",
+      "integrity": "sha512-wnJA4BnEjOSyFMvjZdpiOwhSq9uDoK8e/kpRJDTaMYzwlkrhG1fwDIZI94CLsLzlCK5cIbMMtFlJlfR57Lavmg=="
+    },
+    "vscode-languageserver": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-7.0.0.tgz",
+      "integrity": "sha512-60HTx5ID+fLRcgdHfmz0LDZAXYEV68fzwG0JWwEPBode9NuMYTIxuYXPg4ngO8i8+Ou0lM7y6GzaYWbiDL0drw==",
+      "requires": {
+        "vscode-languageserver-protocol": "3.16.0"
+      }
+    },
+    "vscode-languageserver-protocol": {
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.16.0.tgz",
+      "integrity": "sha512-sdeUoAawceQdgIfTI+sdcwkiK2KU+2cbEYA0agzM2uqaUy2UpnnGHtWTHVEtS0ES4zHU0eMFRGN+oQgDxlD66A==",
+      "requires": {
+        "vscode-jsonrpc": "6.0.0",
+        "vscode-languageserver-types": "3.16.0"
+      }
+    },
+    "vscode-languageserver-textdocument": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.4.tgz",
+      "integrity": "sha512-/xhqXP/2A2RSs+J8JNXpiiNVvvNM0oTosNVmQnunlKvq9o4mupHOBAnnzH0lwIPKazXKvAKsVp1kr+H/K4lgoQ=="
+    },
+    "vscode-languageserver-types": {
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0.tgz",
+      "integrity": "sha512-k8luDIWJWyenLc5ToFQQMaSrqCHiLwyKPHKPQZ5zz21vM+vIVUSvsRpcbiECH4WR88K2XZqc4ScRcZ7nk/jbeA=="
+    },
+    "which": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/which/-/which-5.0.0.tgz",
+      "integrity": "sha512-JEdGzHwwkrbWoGOlIHqQ5gtprKGOenpDHpxE9zVR1bWbOtYRyPPHMe9FaP6x61CmNaTThSkb0DAJte5jD+DmzQ==",
+      "requires": {
+        "isexe": "^3.1.1"
+      }
+    }
+  }
 }

--- a/server/package.json
+++ b/server/package.json
@@ -1,23 +1,23 @@
 {
-	"name": "lfortran-lsp-server",
-	"description": "LFortran LSP server.",
-	"version": "1.0.0",
-	"author": "LCompilers",
-	"license": "MIT",
-	"engines": {
-		"node": "*"
-	},
-	"repository": {
-		"type": "git",
-		"url": "https://github.com/dylon/lfortran-lsp"
-	},
-	"dependencies": {
-		"vscode-languageserver": "^7.0.0",
-		"vscode-languageserver-textdocument": "^1.0.4",
+  "name": "lfortran-lsp-server",
+  "description": "LFortran LSP server.",
+  "version": "1.0.0",
+  "author": "LCompilers",
+  "license": "MIT",
+  "engines": {
+    "node": "*"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/dylon/lfortran-lsp"
+  },
+  "dependencies": {
+    "vscode-languageserver": "^7.0.0",
+    "vscode-languageserver-textdocument": "^1.0.4",
     "which": "5.0.0"
-	},
-	"scripts": {},
-	"devDependencies": {
-		"@types/tmp": "^0.2.3"
-	}
+  },
+  "scripts": {},
+  "devDependencies": {
+    "@types/tmp": "^0.2.3"
+  }
 }

--- a/server/src/lfortran-accessors.ts
+++ b/server/src/lfortran-accessors.ts
@@ -5,8 +5,11 @@ import {
 import {
   Diagnostic,
   DiagnosticSeverity,
+  Location,
+  Position,
+  Range,
   SymbolInformation,
-  SymbolKind
+  SymbolKind,
 } from 'vscode-languageserver/node';
 
 import {
@@ -146,8 +149,19 @@ export class LFortranCLIAccessor implements LFortranAccessor {
     if (Array.isArray(results)) {
       const symbols: SymbolInformation[] = results;
       for (let i = 0, k = symbols.length; i < k; i++) {
-        let symbol = symbols[i];
-        symbol.location.uri = uri;
+        let symbol: SymbolInformation = symbols[i];
+
+        let location: Location = symbol.location;
+        location.uri = uri;
+
+        let range: Range = location.range;
+
+        let start: Position = range.start;
+        start.character--;
+
+        let end: Position = range.end;
+        end.character--;
+
         symbol.kind = SymbolKind.Function;
       }
       return symbols;
@@ -156,10 +170,10 @@ export class LFortranCLIAccessor implements LFortranAccessor {
   }
 
   async lookupName(uri: string,
-                   text: string,
-                   line: number,
-                   column: number,
-                   settings: ExampleSettings): Promise<DefinitionLink[]> {
+    text: string,
+    line: number,
+    column: number,
+    settings: ExampleSettings): Promise<DefinitionLink[]> {
     try {
       const flags = [
         "--lookup-name",
@@ -171,7 +185,14 @@ export class LFortranCLIAccessor implements LFortranAccessor {
       for (let i = 0, k = obj.length; i < k; i++) {
         let location = obj[i].location;
         if (location) {
-          let range = location.range;
+          let range: Range = location.range;
+
+          let start: Position = range.start;
+          start.character--;
+
+          let end: Position = range.end;
+          end.character--;
+
           return [{
             targetUri: uri,
             targetRange: range,

--- a/server/src/lfortran-language-server.ts
+++ b/server/src/lfortran-language-server.ts
@@ -4,19 +4,28 @@
  * ------------------------------------------------------------------------------------------ */
 
 import {
+  CompletionItem,
+  CompletionItemKind,
+  CompletionList,
+  Position,
   _Connection,
   DefinitionLink,
   DefinitionParams,
   Diagnostic,
   DidChangeConfigurationNotification,
   DidChangeConfigurationParams,
-  // DidChangeWatchedFilesParams,
+  DidChangeWatchedFilesParams,
+  DidChangeTextDocumentParams,
   DocumentSymbolParams,
   InitializedParams,
   InitializeParams,
   InitializeResult,
+  Location,
+  Position,
+  Range,
   SymbolInformation,
   TextDocumentChangeEvent,
+  TextDocumentPositionParams,
   TextDocuments,
   TextDocumentSyncKind,
 } from 'vscode-languageserver/node';
@@ -26,6 +35,8 @@ import { TextDocument } from 'vscode-languageserver-textdocument';
 import { ExampleSettings } from './lfortran-types';
 
 import { LFortranAccessor } from './lfortran-accessors';
+
+import { PrefixTrie } from './prefix-trie';
 
 // The global settings, used when the `workspace/configuration` request is not
 // supported by the client. Please note that this is not the case when using
@@ -51,6 +62,8 @@ export class LFortranLanguageServer {
 
   // Cache the settings of all open documents
   public documentSettings: Map<string, Thenable<ExampleSettings>> = new Map();
+
+  public dictionaries = new Map<string, PrefixTrie>();
 
   constructor(lfortran: LFortranAccessor,
               connection: _Connection,
@@ -78,9 +91,13 @@ export class LFortranLanguageServer {
 
     const result: InitializeResult = {
       capabilities: {
-        textDocumentSync: TextDocumentSyncKind.Incremental,
-        documentSymbolProvider: true,
+        completionProvider: {
+          resolveProvider: true,
+          triggerCharacters: ["0","1","2","3","4","5","6","7","8","9","_"],
+        },
         definitionProvider: true,
+        documentSymbolProvider: true,
+        textDocumentSync: TextDocumentSyncKind.Incremental,
       }
     };
 
@@ -109,13 +126,103 @@ export class LFortranLanguageServer {
     // }
   }
 
+  extractDefinition(location: Location): string | undefined {
+    let document = this.documents.get(location.uri);
+    if (document !== undefined) {
+      let range: Range = location.range;
+
+      let start: Position = range.start;
+      let startLine: number = start.line;
+      let startCol: number = start.character;
+
+      let end: Position = range.end;
+      let endLine: number = end.line;
+      let endCol: number = end.character;
+
+      let text = document.getText();
+
+      let currLine = 0;
+      let currCol = 0;
+
+      for (let i = 0, k = text.length; i < k; i++) {
+        let c: string;
+        if ((currLine === startLine) && (currCol === startCol)) {
+          let j = i;
+          for (; (currLine < endLine) || (currLine === endLine) && (currCol <= endCol); j++) {
+            c = text[j];
+            if (c === '\n') {
+              currLine++;
+              currCol = 0;
+            } else if (c === '\r') {
+              let l = j + 1;
+              if ((l < k) && (text[l] === '\n')) {
+                j = l;
+              }
+              currLine++;
+              currCol = 0;
+            } else {
+              currCol++;
+            }
+          }
+          let definition: string = text.substring(i, j);
+          return definition;
+        } else {
+          c = text[i];
+          if (c === '\n') {
+            currLine++;
+            currCol = 0;
+          } else if (c === '\r') {
+            let j = i + 1;
+            if ((j < k) && (text[j] === '\n')) {
+              i = j;
+            }
+            currLine++;
+            currCol = 0;
+          } else {
+            currCol++;
+          }
+        }
+      }
+    }
+  }
+
+  index(uri: string, symbols: SymbolInformation[]): void {
+    if (symbols.length > 0) {
+      // (symbols.length == 0) => error with document, but we still need to
+      // support auto-completion.
+      let terms: string[] = [];
+      let values: CompletionItem[] = [];
+      for (let i = 0, k = symbols.length; i < k; i++) {
+        let symbol: SymbolInformation = symbols[i];
+        let definition: string | undefined =
+          this.extractDefinition(symbol.location);
+        terms.push(symbol.name);
+        values.push({
+          label: symbol.name,
+          // FIXME: Once lfortran returns the correct symbol kinds, map them
+          // to their corresponding completion kind, here.
+          // ---------------------------------------------------------------
+          // kind: symbol.kind,
+          kind: CompletionItemKind.Text,
+          detail: definition,
+        });
+      }
+      // TODO: Index temporary file by URI (maybe)
+      let dictionary = PrefixTrie.from(terms, values);
+      this.dictionaries.set(uri, dictionary);
+    }
+  }
+
   async onDocumentSymbol(request: DocumentSymbolParams): Promise<SymbolInformation[] | undefined> {
     const uri = request.textDocument.uri;
     const document = this.documents.get(uri);
     const settings = await this.getDocumentSettings(uri);
     const text = document?.getText();
     if (typeof text === "string") {
-      return await this.lfortran.showDocumentSymbols(uri, text, settings);
+      let symbols: SymbolInformation[] =
+        await this.lfortran.showDocumentSymbols(uri, text, settings);
+      this.index(uri, symbols);
+      return symbols;
     }
   }
 
@@ -189,4 +296,70 @@ export class LFortranLanguageServer {
   //   // Monitored files have change in VSCode
   //   this.connection.console.log('We received an file change event');
   // }
+
+  isIdentifiable(c: string): boolean {
+    // A character `c` may be part of an identifier if it is a member of the
+    // range `[a-zA-Z0-9_]`.
+    return (('0' <= c) && (c <= '9')) ||
+      (('A' <= c) && (c <= 'z')) ||
+      (c == '_');
+  }
+
+  extractQuery(text: string, line: number, column: number): string | null {
+    let isIdentifiable = this.isIdentifiable;
+    let currLine = 0;
+    let currCol = 0;
+
+    for (let i = 0, k = text.length; i < k; i++) {
+      let c: string = text[i];
+      if (c === '\n') {
+        currLine++;
+        currCol = 0;
+      } else if (c === '\r') {
+        let j = i + 1;
+        if ((j < k) && (text[j] === '\n')) {
+          i = j;
+        }
+        currLine++;
+        currCol = 0;
+      } else {
+        currCol++;
+      }
+
+      if ((line === currLine) && (column === currCol)) {
+        if (isIdentifiable(c)) {
+          let l = i;
+          let u = i + 1;
+          while ((l > 0) && isIdentifiable(text[l - 1])) {
+            l--;
+          }
+          while ((u < k) && isIdentifiable(text[u])) {
+            u++;
+          }
+          let query = text.substring(l, u);
+          return query;
+        }
+      }
+    }
+
+    return null;
+  }
+
+  async onCompletion(documentPosition: TextDocumentPositionParams): Promise<CompletionItem[] | CompletionList | undefined> {
+    let uri: string = documentPosition.textDocument.uri;
+    let document = this.documents.get(uri);
+    let dictionary = this.dictionaries.get(uri);
+    if ((document !== undefined) && (dictionary !== undefined)) {
+      let text: string = document.getText();
+      let pos: Position = documentPosition.position;
+      let query: string | null = this.extractQuery(text, pos.line, pos.character);
+      if (query !== null) {
+        return Array.from(dictionary.lookup(query)) as CompletionItem[];
+      }
+    }
+  }
+
+  onCompletionResolve(item: CompletionItem): CompletionItem {
+    return item;
+  }
 }

--- a/server/src/main.ts
+++ b/server/src/main.ts
@@ -31,6 +31,8 @@ connection.onDocumentSymbol(server.onDocumentSymbol.bind(server));
 connection.onDefinition(server.onDefinition.bind(server));
 connection.onDidChangeConfiguration(server.onDidChangeConfiguration.bind(server));
 // connection.onDidChangeWatchedFiles(server.onDidChangeWatchedFiles.bind(server));
+connection.onCompletion(server.onCompletion.bind(server));
+connection.onCompletionResolve(server.onCompletionResolve.bind(server));
 
 documents.onDidClose(server.onDidClose.bind(server));
 documents.onDidChangeContent(server.onDidChangeContent.bind(server));

--- a/server/src/prefix-trie.ts
+++ b/server/src/prefix-trie.ts
@@ -249,7 +249,10 @@ export class PrefixTrie {
     return dict;
   }
 
-  insert(term: string, value: object | string): boolean {
+  insert(term: string, value?: object | string): boolean {
+    if (value === undefined) {
+      value = term;
+    }
     term = term.toLowerCase();
     let curr: PrefixNode = this.root;
     let path: PrefixNode[] = [];

--- a/server/src/prefix-trie.ts
+++ b/server/src/prefix-trie.ts
@@ -1,0 +1,340 @@
+export class PrefixNode {
+  public isFinal: boolean = false;
+  public edges: Map<string, PrefixNode> = new Map();
+
+  public parent?: PrefixNode;
+  public label?: string;
+  public term?: string;
+
+  constructor(label?: string, parent?: PrefixNode) {
+    this.parent = parent;
+    this.label = label;
+  }
+
+  addEdge(label: string): PrefixNode {
+    let child: PrefixNode | undefined = this.edges.get(label);
+    if (child === undefined) {
+      child = new PrefixNode(label, this);
+      this.edges.set(label, child);
+    }
+    return child;
+  }
+
+  transition(label: string): PrefixNode | undefined {
+    let child: PrefixNode | undefined = this.edges.get(label);
+    return child;
+  }
+
+  buffer(ss: string[]): string[] {
+    if (this.parent !== undefined) {
+      this.parent.buffer(ss);
+      // @ts-ignore: next-line
+      ss.push(this.label);
+    }
+    return ss;
+  }
+
+  collect(): string {
+    if (this.term === undefined) {
+      let ss: string[] = [];
+      this.buffer(ss);
+      this.term = ss.join("");
+    }
+    return this.term;
+  }
+
+  toString(): string {
+    let ss: string[] = [];
+    ss.push("PrefixNode{isFinal=");
+    ss.push(this.isFinal.toString());
+    ss.push(",edges=");
+    ss.push(this.edges.size.toString());
+    ss.push(',prefix="');
+    this.buffer(ss);
+    ss.push('"}');
+    return ss.join("");
+  }
+
+  equalsPrefix(that: any): boolean {
+    return (that instanceof PrefixNode) &&
+      ((this.parent === undefined) === (that.parent === undefined)) &&
+      ((this.parent === undefined) ||
+        this.parent.equalsPrefix(that.parent)) &&
+      (this.label === that.label);
+  }
+
+  equalsSuffix(that: any): boolean {
+    return (that instanceof PrefixNode) &&
+      (this.isFinal === that.isFinal) &&
+      (this.label === that.label) &&
+      (this.edges.size === that.edges.size) &&
+      Array.from(this.edges).every(([label, thisChild]) => {
+        let thatChild = that.edges.get(label);
+        return thisChild.equalsSuffix(thatChild);
+      });
+  }
+
+  equals(that: any): boolean {
+    return this.equalsPrefix(that) && this.equalsSuffix(that);
+  }
+}
+
+interface IteratorValue<T> {
+  value: T | null;
+  done: boolean;
+}
+
+export class PrefixIterator {
+  private pending: PrefixNode[] = [];
+  private ss: string[] = [];
+  private value: string | null = null;
+  public done: boolean = false;
+
+  constructor(node?: PrefixNode) {
+    if (node !== undefined) {
+      this.pending.push(node);
+      this.advance();
+    }
+  }
+
+  next(): IteratorValue<string | null> {
+    this.advance();
+    let value = this.value;
+    this.value = null;
+    return {
+      value: value,
+      done: this.done
+    };
+  }
+
+  advance(): void {
+    if ((this.value === null) && (this.pending.length > 0)) {
+      do {
+        // @ts-ignore: next-line
+        let node: PrefixNode = this.pending.shift();
+        for (let child of node.edges.values()) {
+          this.pending.push(child);
+        }
+        if (node.isFinal) {
+          if (node.term === undefined) {
+            this.ss.length = 0;
+            node.buffer(this.ss);
+            node.term = this.ss.join("");
+          }
+          this.value = node.term;
+          break;
+        }
+      } while (this.pending.length > 0);
+    }
+    this.done = (this.value === null);
+  }
+
+  [Symbol.iterator](): PrefixIterator {
+    return this;
+  }
+
+  toString(): string {
+    let buffer: string[] = [];
+    let pending: PrefixNode[] = this.pending;
+    buffer.push("PrefixIterator{value=");
+    if (this.value !== null) {
+      buffer.push('"');
+      buffer.push(this.value);
+      buffer.push('"');
+    } else {
+      buffer.push("null");
+    }
+    buffer.push(",pending={length=");
+    buffer.push(pending.length.toString());
+    buffer.push(",values=[");
+    for (let i = 0, k = pending.length; i < k; i++) {
+      let node: PrefixNode = pending[i];
+      buffer.push('"');
+      buffer.push(node.toString());
+      buffer.push('"');
+      if ((i + 1) < k) {
+        buffer.push(",");
+      }
+    }
+    buffer.push("]}}");
+    return buffer.join("");
+  }
+
+  equals(that: any): boolean {
+    return (that instanceof PrefixIterator) &&
+      (this.value === that.value) &&
+      (this.pending.length === that.pending.length) &&
+      this.pending.every((thisNode: PrefixNode, index: number) => {
+        let thatNode: PrefixNode = that.pending[index];
+        return thisNode.equals(thatNode);
+      });
+  }
+}
+
+export class PrefixCursor {
+  public curr?: PrefixNode;
+  public prev?: PrefixNode;
+
+  constructor(node?: PrefixNode) {
+    this.curr = node;
+    this.prev = node?.parent;
+  }
+
+  seek(suffix: string | string[]): boolean {
+    let prev = this.prev;
+    let curr = this.curr;
+    for (let i = 0, k = suffix.length;
+         (i < k) && (curr !== undefined);
+         i++) {
+      let label: string = suffix[i];
+      prev = curr;
+      curr = curr.transition(label);
+    }
+    this.prev = prev;
+    this.curr = curr;
+    return (this.curr !== undefined);
+  }
+
+  rewind(numSteps: number): boolean {
+    let prev = this.prev;
+    let curr = this.curr;
+    while ((numSteps > 0) && (prev !== undefined)) {
+      curr = prev;
+      prev = prev.parent;
+      numSteps--;
+    }
+    this.prev = prev;
+    this.curr = curr;
+    return (this.curr !== undefined);
+  }
+
+  [Symbol.iterator](): PrefixIterator {
+    return new PrefixIterator(this.curr);
+  }
+
+  toString(): string {
+    let prev: string = (this.prev !== undefined) ? `"${this.prev}"` : "null";
+    let curr: string = (this.curr !== undefined) ? `"${this.curr}"` : "null";
+    return `PrefixCursor{prev=${prev},curr=${curr}}`;
+  }
+
+  equals(that: any): boolean {
+    return (that instanceof PrefixCursor) &&
+      ((this.curr === undefined) === (that.curr === undefined)) &&
+      ((this.curr === undefined) ||
+        this.curr.equals(that.curr)) &&
+      ((this.prev === undefined) === (that.prev === undefined)) &&
+      ((this.prev === undefined) ||
+        this.prev.equals(that.prev));
+  }
+}
+
+export class PrefixTrie {
+  public root: PrefixNode = new PrefixNode();
+  public size: number = 0;
+
+  insert(term: string): boolean {
+    let curr: PrefixNode = this.root;
+    for (let i = 0, k = term.length; i < k; i++) {
+      let label: string = term[i];
+      curr = curr.addEdge(label);
+    }
+    if (curr.isFinal) {
+      return false;
+    }
+    curr.isFinal = true;
+    curr.term = term;
+    this.size++;
+    return true;
+  }
+
+  remove(term: string): boolean {
+    let curr: PrefixNode | undefined = this.root;
+    for (let i = 0, k = term.length;
+         (i < k) && (curr !== undefined);
+         i++) {
+      let label: string = term[i];
+      curr = curr.transition(label);
+    }
+    if ((curr === undefined) || !curr.isFinal) {
+      return false;
+    }
+    curr.isFinal = false;
+    curr.term = undefined;
+    while ((curr.edges.size === 0) && !curr.isFinal) {
+      let label: string | undefined = curr.label;
+      curr = curr.parent;
+      if (curr === undefined) {
+        break;
+      }
+      curr.edges.delete(label);
+    }
+    this.size--;
+    return true;
+  }
+
+  lookup(term: string): PrefixIterator | undefined {
+    let curr: PrefixNode | undefined = this.root;
+    for (let i = 0, k = term.length; i < k; i++) {
+      let label: string = term[i];
+      curr = curr.transition(label);
+      if (curr === undefined) {
+        break;
+      }
+    }
+    if (curr === undefined) {
+      return undefined;
+    }
+    return new PrefixIterator(curr);
+  }
+
+  contains(term: string): boolean {
+    let curr: PrefixNode | undefined = this.root;
+    for (let i = 0, k = term.length;
+         (i < k) && (curr !== undefined);
+         i++) {
+      let label: string = term[i];
+      curr = curr.transition(label);
+    }
+    return (curr !== undefined) && curr.isFinal;
+  }
+
+  cursor() : PrefixCursor {
+    return new PrefixCursor(this.root);
+  }
+
+  [Symbol.iterator](): PrefixIterator {
+    return new PrefixIterator(this.root);
+  }
+
+  toString(): string {
+    let buffer: string[] = [];
+    buffer.push("PrefixTrie{size=");
+    buffer.push(this.size.toString())
+    buffer.push(",terms=[");
+    let iter: PrefixIterator = this[Symbol.iterator]();
+    let { "value": term, "done": done } = iter.next();
+    if (!done) {
+      buffer.push('"');
+      buffer.push(term);
+      buffer.push('"');
+      do {
+        let { "value": term, "done": done } = iter.next();
+        if (done) {
+          break;
+        }
+        buffer.push(',"');
+        buffer.push(term);
+        buffer.push('"');
+      } while (true);
+    }
+    buffer.push("]}");
+    return buffer.join("");
+  }
+
+  equals(that: any): boolean {
+    return (that instanceof PrefixTrie) &&
+      (this.size === that.size) &&
+      this.root.equals(that.root);
+  }
+}

--- a/server/test/spec/lfortran-accessors.spec.ts
+++ b/server/test/spec/lfortran-accessors.spec.ts
@@ -51,7 +51,7 @@ describe("LFortranCLIAccessor", () => {
     });
 
     it("returns the expected symbol information", async () => {
-      let expected: SymbolInformation[] = [
+      let response: SymbolInformation[] = [
         {
           name: "foo",
           // NOTE: Right now, the kind is hard-coded to Function ...
@@ -89,7 +89,13 @@ describe("LFortranCLIAccessor", () => {
           }
         },
       ];
-      let stdout = JSON.stringify(expected);
+      let stdout = JSON.stringify(response);
+      let expected = response;
+      for (let symbol of expected) {
+        let range = symbol.location.range;
+        range.start.character--;
+        range.end.character--;
+      }
       let actual = await lfortran.showDocumentSymbols(uri, stdout, settings);
       assert.deepEqual(actual, expected);
     });
@@ -156,6 +162,9 @@ describe("LFortranCLIAccessor", () => {
           }
         }
       ]);
+
+      range.start.character--;
+      range.end.character--;
 
       let actual = await lfortran.lookupName(uri, stdout, line, column, settings);
       assert.deepEqual(actual, expected);

--- a/server/test/spec/lfortran-language-server.spec.ts
+++ b/server/test/spec/lfortran-language-server.spec.ts
@@ -95,7 +95,7 @@ describe("LFortranLanguageServer", () => {
     };
 
     it("Returns all the symbols", async () => {
-      let expected: SymbolInformation[] = [
+      let response: SymbolInformation[] = [
         {
           name: "baz",
           // NOTE: Right now, the kind is hard-coded to Function ...
@@ -134,8 +134,15 @@ describe("LFortranLanguageServer", () => {
         },
       ];
 
-      let stdout = JSON.stringify(expected);
+      let stdout = JSON.stringify(response);
       document.getText.returns(stdout);
+
+      let expected = response;
+      for (let symbol of expected) {
+        let range = symbol.location.range;
+        range.start.character--;
+        range.end.character--;
+      }
 
       let actual = await server.onDocumentSymbol(request);
       assert.deepEqual(actual, expected);
@@ -196,6 +203,9 @@ describe("LFortranLanguageServer", () => {
       ]);
 
       document.getText.returns(stdout);
+
+      range.start.character--;
+      range.end.character--;
 
       let actual = await server.onDefinition(request);
       assert.deepEqual(actual, expected);

--- a/server/test/spec/prefix-trie.spec.ts
+++ b/server/test/spec/prefix-trie.spec.ts
@@ -337,12 +337,15 @@ describe("PrefixTrie", () => {
           for (let term of terms) {
             let inserted: boolean = dict.insert(term);
             assert.equal(inserted, !visited.has(term));
-            visited.add(term);
+            visited.add(term.toLowerCase());
 
             let found: boolean = false;
             for (let candidate of dict.lookup(term)) {
-              assert.isTrue(candidate.startsWith(term));
-              found ||= (candidate === term);
+              let lowercaseCandidate = candidate.toLowerCase();
+              let lowercaseTerm = term.toLowerCase();
+              assert.isTrue(lowercaseCandidate.startsWith(lowercaseTerm),
+                            `Expected "${lowercaseCandidate}" to start with "${lowercaseTerm}"`);
+              found ||= (lowercaseCandidate === lowercaseTerm);
             }
             assert.isTrue(found);
           }
@@ -350,8 +353,9 @@ describe("PrefixTrie", () => {
           assert.equal(dict.size, visited.size);
 
           for (let term of dict) {
-            assert.include(visited, term);
-            visited.delete(term);
+            let lowercaseTerm = term.toLowerCase();
+            assert.include(visited, lowercaseTerm);
+            visited.delete(lowercaseTerm);
           }
           assert.isEmpty(visited);
         }

--- a/server/test/spec/prefix-trie.spec.ts
+++ b/server/test/spec/prefix-trie.spec.ts
@@ -1,0 +1,399 @@
+import {
+  PrefixCursor,
+  PrefixIterator,
+  PrefixNode,
+  PrefixTrie,
+} from "../../src/prefix-trie";
+
+import { assert } from "chai";
+
+import "mocha";
+
+import fc from "fast-check";
+
+interface PrefixPath {
+  root: PrefixNode;
+  leaf: PrefixNode;
+}
+
+describe("PrefixNode", () => {
+  let chart = (term: string): PrefixPath => {
+    let root: PrefixNode = new PrefixNode();
+    let leaf: PrefixNode = root;
+    for (let i = 0, k = term.length; i < k; i++) {
+      let label = term[i];
+      leaf = leaf.addEdge(label);
+    }
+    leaf.isFinal = true;
+    return { root, leaf };
+  };
+
+  it("reconstructs the original term", () => {
+    fc.assert(
+      fc.property(
+        fc.string(),
+        (term: string): void => {
+          let { leaf } = chart(term);
+          let prefix: string = leaf.collect();
+          assert.equal(prefix, term);
+        }
+      )
+    );
+  });
+
+  it("transitions along the path of the term", () => {
+    fc.assert(
+      fc.property(
+        fc.string(),
+        (term: string): void => {
+          let { root } = chart(term);
+          let path: PrefixNode = root;
+          for (let i = 0, k = term.length; i < k; i++) {
+            let label: string = term[i];
+            path = path.transition(label);
+            assert.isDefined(path);
+          }
+          assert.isTrue(path.isFinal);
+        }
+      )
+    );
+  });
+
+  it("is comparable with other PrefixNodes", () => {
+    fc.assert(
+      fc.property(
+        fc.string(),
+        fc.string(),
+        (v: string, w: string): void => {
+          let { "root": lhs } = chart(v);
+          let { "root": rhs } = chart(v);
+          assert.isTrue(
+            lhs.equals(rhs),
+            `Expected ${lhs} to equal ${rhs} for term="${v}"`
+          );
+          if (v !== w) {
+            let { "root": rhs } = chart(w);
+            assert.isFalse(
+              lhs.equals(rhs),
+              `Expected ${lhs} to not equal ${rhs} for terms v="${v}" and w="${w}"`
+            );
+          }
+        }
+      )
+    );
+  });
+});
+
+function insert(root: PrefixNode, term: string): PrefixNode {
+  let curr: PrefixNode = root;
+  for (let i = 0, k = term.length; i < k; i++) {
+    let label = term[i];
+    curr = curr.addEdge(label);
+  }
+  curr.isFinal = true;
+  return curr;
+};
+
+describe("PrefixIterator", () => {
+  it("iterates over all the terms reachable from the root", () => {
+    fc.assert(
+      fc.property(
+        fc.uniqueArray(fc.string()),
+        (terms: string[]): void => {
+          let root: PrefixNode = new PrefixNode();
+          for (let term of terms) {
+            let leaf: PrefixNode = insert(root, term);
+            assert.equal(leaf.collect(), term);  // sanity check
+          }
+
+          // Validate against explicit iterator operations
+          let pending: Set<string> = new Set(terms);
+          let iter = new PrefixIterator(root);
+          assert.equal(iter.done, (terms.length === 0));
+          while (!iter.done) {
+            let { "value": term, done } = iter.next();
+            if (done) {
+              assert.isNull(term);
+              assert.isTrue(iter.done);
+            } else {
+              assert.include(pending, term);
+              pending.delete(term);
+            }
+          }
+          assert.isEmpty(pending);
+
+          // Validate against implicit iterator operations
+          pending = new Set(terms);
+          for (let term of new PrefixIterator(root)) {
+            assert.include(pending, term);
+            pending.delete(term);
+          }
+          assert.isEmpty(pending);
+        }
+      )
+    );
+  });
+
+  it("is comparable against other PrefixIterators", () => {
+    fc.assert(
+      fc.property(
+        fc.uniqueArray(fc.string()),
+        fc.uniqueArray(fc.string()),
+        (vs: string[], ws: string[]): void => {
+          let vt = new PrefixNode();
+          let wt = new PrefixNode();
+          for (let v of vs) {
+            insert(vt, v);
+          }
+          for (let w of ws) {
+            insert(wt, w);
+          }
+          assert.isTrue(
+            new PrefixIterator(vt).equals(new PrefixIterator(vt)),
+            `Expected iterators over ${vs} to be equivalent.`
+          );
+          if ((vs.length === ws.length) && vs.every((v, i) => (v === ws[i]))) {
+            assert.isTrue(
+              new PrefixIterator(vt).equals(new PrefixIterator(wt)),
+              `Expected iterators over ${vs} and ${ws} to be equivalent.`
+            );
+          } else {
+            assert.isFalse(
+              new PrefixIterator(vt).equals(new PrefixIterator(wt)),
+              `Expected iterators over ${vs} and ${ws} to be inequivalent.`
+            );
+          }
+        }
+      )
+    );
+  });
+});
+
+describe("PrefixCursor", () => {
+  let alphabet = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+
+  let alphanumeric = (gen): string => {
+    let index: number = gen(fc.nat, { max: alphabet.length - 1 });
+    let alnum: string = alphabet[index];
+    return alnum;
+  };
+
+  let ins = (buffer: string[], index: number, value: string): void => {
+    buffer.splice(index, 0, value);
+  };
+
+  let del = (buffer: string[], index: number): void => {
+    buffer.splice(index, 1);
+  };
+
+  let sub = (buffer: string[], index: number, value: string): void => {
+    buffer[index] = value;
+  };
+
+  let mutate = (gen, buffer: string[]): number => {
+    let index: number;
+    if (buffer.length === 0) {
+      index = 0;
+      let value: string = alphanumeric(gen);
+      buffer.push(value);
+    } else {
+      index = gen(fc.nat, { max: buffer.length - 1 });
+      let op = gen(fc.nat, { max: 2 });
+      switch (op) {
+        case 0: {
+          let value: string = alphanumeric(gen);
+          ins(buffer, index, value);
+          break;
+        }
+        case 1: {
+          del(buffer, index);
+          break;
+        }
+        case 2: {
+          let value: string = alphanumeric(gen);
+          sub(buffer, index, value);
+          break;
+        }
+      }
+    }
+    return index;
+  };
+
+  let uniform = (gen): number => {
+    return gen(fc.double, { min: 0.0, max: 1.0 });
+  }
+
+  let selectWeighted = (gen, probability: number): boolean => {
+    return uniform(gen) <= probability;
+  };
+
+  let normalized = (length: number): number => {
+    return 1.0 / length;
+  };
+
+  let sampleLabel = (gen, node: PrefixNode): string | undefined => {
+    let prev: string | undefined;
+    let prob: number = normalized(node.edges.size);
+    for (let label of node.edges.keys()) {
+      if (selectWeighted(gen, prob)) {
+        return label;
+      }
+      prev = label;
+    }
+    return prev;
+  };
+
+  let checkCandidates = (terms: string[],
+                         cursor: PrefixCursor,
+                         buffer: string[]): void => {
+    let prefix = buffer.join("");
+    let expected = terms.filter(term => term.startsWith(prefix));
+    let actual: string[] = Array.from(cursor);
+    expected.sort();
+    actual.sort();
+    assert.deepEqual(actual, expected);
+  };
+
+  it("navigates forward as the user types", () => {
+    fc.assert(
+      fc.property(
+        fc.gen(),
+        fc.uniqueArray(fc.string()),
+        (gen, terms: string[]) => {
+          let root = new PrefixNode();
+          for (let term of terms) {
+            insert(root, term);
+          }
+
+          let cursor = new PrefixCursor(root);
+          let buffer: string[] = [];
+          checkCandidates(terms, cursor, buffer);
+
+          while (cursor.curr !== undefined) {
+            let label: string;
+            if (selectWeighted(gen, 0.85)) {
+              label = sampleLabel(gen, cursor.curr);
+              if (label === undefined) {
+                // If we've reached the end of the branch, generate an arbitrary
+                // character to append.
+                label = alphanumeric(gen);
+              }
+            } else {
+              // With a small probability, generate a likely error.
+              label = alphanumeric(gen);
+            }
+            buffer.push(label);
+            cursor.seek(label);
+            checkCandidates(terms, cursor, buffer);
+          }
+        }
+      )
+    );
+  });
+
+  it("can backtrack when the term is edited inline", () => {
+    fc.assert(
+      fc.property(
+        fc.gen(),
+        fc.uniqueArray(fc.string()),
+        (gen, terms: string[]) => {
+          let root = new PrefixNode();
+          for (let term of terms) {
+            insert(root, term);
+          }
+
+          let cursor = new PrefixCursor(root);
+          let buffer: string[] = [];
+          checkCandidates(terms, cursor, buffer);
+
+          while (cursor.curr !== undefined) {
+            let label: string | undefined = sampleLabel(gen, cursor.curr);
+            if (label !== undefined) {
+              buffer.push(label);
+              cursor.seek(label);
+            }
+            let length: number = buffer.length;
+            let index: number = mutate(gen, buffer);
+            let numSteps: number = length - index;
+            cursor.rewind(numSteps);
+            let suffix: string[] = buffer.slice(index);
+            cursor.seek(suffix);
+            checkCandidates(terms, cursor, buffer);
+          }
+        }
+      )
+    );
+  })
+});
+
+describe("PrefixTrie", () => {
+  it("behaves like a collection of terms", () => {
+    fc.assert(
+      fc.property(
+        fc.array(fc.string()),
+        (terms: string[]) => {
+          let dict = new PrefixTrie();
+          let visited = new Set<string>();
+          for (let term of terms) {
+            let inserted: boolean = dict.insert(term);
+            assert.equal(inserted, !visited.has(term));
+            visited.add(term);
+
+            let found: boolean = false;
+            for (let candidate of dict.lookup(term)) {
+              assert.isTrue(candidate.startsWith(term));
+              found ||= (candidate === term);
+            }
+            assert.isTrue(found);
+          }
+
+          assert.equal(dict.size, visited.size);
+
+          for (let term of dict) {
+            assert.include(visited, term);
+            visited.delete(term);
+          }
+          assert.isEmpty(visited);
+        }
+      )
+    );
+  });
+
+  it("can delete terms", () => {
+    let shuffle = (terms: string[]): void => {
+      for (let i = terms.length; i !== 0;) {
+        let j = Math.floor(Math.random() * (i--));
+        [terms[i], terms[j]] = [terms[j], terms[i]];
+      }
+    };
+
+    fc.assert(
+      fc.property(
+        fc.array(fc.string()),
+        (terms: string[]) => {
+          let dict = new PrefixTrie();
+          let visited = new Set<string>(terms);
+          for (let term of terms) {
+            dict.insert(term);
+          }
+
+          // delete them in a different order
+          shuffle(terms);
+
+          for (let term of terms) {
+            if (visited.has(term)) {
+              assert.isTrue(dict.contains(term));
+              assert.isTrue(dict.remove(term));
+              visited.delete(term);
+            } else {
+              assert.isFalse(dict.contains(term));
+              assert.isFalse(dict.remove(term));
+            }
+          }
+          assert.equal(dict.size, visited.size);
+          assert.equal(dict.size, 0);
+        }
+      )
+    );
+  });
+});

--- a/server/test/spec/prefix-trie.spec.ts
+++ b/server/test/spec/prefix-trie.spec.ts
@@ -335,9 +335,10 @@ describe("PrefixTrie", () => {
           let dict = new PrefixTrie();
           let visited = new Set<string>();
           for (let term of terms) {
+            let lowercaseTerm = term.toLowerCase();
             let inserted: boolean = dict.insert(term);
-            assert.equal(inserted, !visited.has(term));
-            visited.add(term.toLowerCase());
+            assert.equal(inserted, !visited.has(lowercaseTerm));
+            visited.add(lowercaseTerm);
 
             let found: boolean = false;
             for (let candidate of dict.lookup(term)) {
@@ -376,7 +377,7 @@ describe("PrefixTrie", () => {
         fc.array(fc.string()),
         (terms: string[]) => {
           let dict = new PrefixTrie();
-          let visited = new Set<string>(terms);
+          let visited = new Set<string>(terms.map(term => term.toLowerCase()));
           for (let term of terms) {
             dict.insert(term);
           }
@@ -385,13 +386,14 @@ describe("PrefixTrie", () => {
           shuffle(terms);
 
           for (let term of terms) {
-            if (visited.has(term)) {
-              assert.isTrue(dict.contains(term));
-              assert.isTrue(dict.remove(term));
-              visited.delete(term);
+            let lowercaseTerm = term.toLowerCase();
+            if (visited.has(lowercaseTerm)) {
+              assert.isTrue(dict.contains(lowercaseTerm));
+              assert.isTrue(dict.remove(lowercaseTerm));
+              visited.delete(lowercaseTerm);
             } else {
-              assert.isFalse(dict.contains(term));
-              assert.isFalse(dict.remove(term));
+              assert.isFalse(dict.contains(lowercaseTerm));
+              assert.isFalse(dict.remove(lowercaseTerm));
             }
           }
           assert.equal(dict.size, visited.size);


### PR DESCRIPTION
Major changes:
1. Adds support for code completion with definition previews.
2. Minor bug fixes:
    1. Fixes error where client main script pointed to the wrong location (issue with development artifacts).
    2. Renames the configuration from `"Example configuration"` to `"LFortran Language Server"` (visible in VSCode's settings).
    3. Decrements the column offsets from lfortran by one for correctness.

Notes:
1. Prefix tries are used to index terms for code completion.
2. The final nodes of the prefix tries, representing ending characters of completion terms, map to values of type `CompletionItem` so lookups can be performed quickly.
3. These indices will be used for hover previews and anywhere else they are useful.
4. VSCode does its own filtering atop whatever we return for code completion, so our `onCompletion` handler is not always guaranteed to be called and it is not guaranteed that all the results we return will be presented to the user for completion.
5. We can force VSCode to always call our `onCompletion` handler on keystrokes but cannot prevent it from post-processing (filtering) our results.