### PR TITLE
Adds initial support for renaming symbols

### DIFF
--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -75,7 +75,8 @@ function activate-conda() {
           pandoc \
           gcc \
           gxx \
-          libcxx
+          libcxx \
+          rapidjson
     RETURN_CODE=$?
     if (( RETURN_CODE != EXIT_SUCCESS )); then
       echo "`conda create -n $CONDA_ENV` failed with status $RETURN_CODE" 1>&2

--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -143,7 +143,12 @@ function build-lfortran() {
       return $EXIT_BUILD_FAILED
     fi
 
-    cmake --fresh -DCMAKE_BUILD_TYPE=Debug -DWITH_LSP=yes -DWITH_LLVM=yes -DCMAKE_INSTALL_PREFIX=`pwd`/inst .
+    cmake --fresh \
+          -DCMAKE_BUILD_TYPE=Debug \
+          -DWITH_LSP=yes \
+          -DWITH_LLVM=yes \
+          -DWITH_JSON=yes \
+          -DCMAKE_INSTALL_PREFIX=`pwd`/inst .
     RETURN_CODE=$?
     if (( RETURN_CODE != EXIT_SUCCESS )); then
       echo "cmake failed with status $RETURN_CODE" 1>&2
@@ -191,6 +196,8 @@ Usage: ./scripts/e2e.sh [OPTIONS]
 Options:
   -h|--help             Print this help text.
   -u|--update-lfortran  Whether to update LFortran before running the end-to-end tests.
+  --headless            Whether to run the tests in an XVFB framebuffer
+                        (render off-screen; no visible window).
 EOF
 }
 

--- a/server/src/main.ts
+++ b/server/src/main.ts
@@ -34,6 +34,7 @@ connection.onDidChangeConfiguration(server.onDidChangeConfiguration.bind(server)
 connection.onCompletion(server.onCompletion.bind(server));
 connection.onCompletionResolve(server.onCompletionResolve.bind(server));
 connection.onHover(server.onHover.bind(server));
+connection.onRenameRequest(server.onRenameRequest.bind(server));
 
 documents.onDidClose(server.onDidClose.bind(server));
 documents.onDidChangeContent(server.onDidChangeContent.bind(server));

--- a/server/test/spec/lfortran-accessors.spec.ts
+++ b/server/test/spec/lfortran-accessors.spec.ts
@@ -5,6 +5,7 @@ import {
   Range,
   SymbolInformation,
   SymbolKind,
+  TextEdit,
 } from "vscode-languageserver/node";
 
 import { LFortranCLIAccessor } from "../../src/lfortran-accessors";
@@ -248,6 +249,84 @@ describe("LFortranCLIAccessor", () => {
 
       sinon.stub(lfortran, "runCompiler").resolves(stdout);
       const actual = await lfortran.showErrors(uri, "", settings);
+      assert.deepEqual(actual, expected);
+    });
+  });
+
+  describe("renameSymbol", () => {
+    it("decrements the exclusive ending character values to make them inclusive columns", async () => {
+      const newName: string = "foo";
+
+      const stdout: string = JSON.stringify([
+        {
+          kind: 1,
+          location: {
+            range: {
+              start: {
+                character: 5,
+                line: 8
+              },
+              end: {
+                character: 25,
+                line: 12
+              }
+            },
+            uri: "uri"
+          },
+          name: "eval_1d"
+        },
+        {
+          kind: 1,
+          location: {
+            range: {
+              start: {
+                character: 7,
+                line: 4
+              },
+              end: {
+                character: 28,
+                line: 4
+              }
+            },
+            uri: "uri"
+          },
+          name: "eval_1d"
+        }
+      ]);
+
+      sinon.stub(lfortran, "runCompiler").resolves(stdout);
+
+      const expected: TextEdit[] = [
+        {
+          range: {
+            start: {
+              line: 8,
+              character: 4,
+            },
+            end: {
+              line: 12,
+              character: 24,
+            }
+          },
+          newText: newName,
+        },
+        {
+          range: {
+            start: {
+              line: 4,
+              character: 6,
+            },
+            end: {
+              line: 4,
+              character: 27,
+            }
+          },
+          newText: newName,
+        },
+      ];
+
+      const actual: TextEdit[] =
+        await lfortran.renameSymbol(uri, "", 18, 22, newName, settings);
       assert.deepEqual(actual, expected);
     });
   });


### PR DESCRIPTION
Changes:
1. Adds workaround to rename symbols in lieu of lfortran/lfortran issue #5524
2. Attempts to repair error messages from lfortran in lieu of lfortran/lfortran issue #5525
3. Fixes off-by-one error in extractQuery
4. Adds respective unit/integration/regression tests
5. Adds missing docstring for --headless to e2e.sh