### PR TITLE
Adds support for highlighting symbols

### DIFF
--- a/integ/spec/function_call1.f90.spec.ts
+++ b/integ/spec/function_call1.f90.spec.ts
@@ -166,47 +166,47 @@ async function getErrorAlert(): Promise<string> {
   throw new Error("This should not be reached!");
 }
 
-const GET_FONT: string = `
-  const element = arguments[0];
-  const style = window.getComputedStyle(element);
-  const fontFamily = style.fontFamily;
-  const fontSize = style.fontSize;
-  const fontStretch = style.fontStretch;
-  const fontStyle = style.fontStyle;
-  const fontVariant = style.fontVariant;
-  const fontWeight = style.fontWeight;
-  const lineHeight = style.lineHeight;
-  const font = [
-    fontStyle,
-    fontVariant,
-    fontWeight,
-    fontSize + "/" + lineHeight,
-    fontStretch,
-    fontFamily,
-  ].join(" ");
-  return font;
-`;
+// const GET_FONT: string = `
+//   const element = arguments[0];
+//   const style = window.getComputedStyle(element);
+//   const fontFamily = style.fontFamily;
+//   const fontSize = style.fontSize;
+//   const fontStretch = style.fontStretch;
+//   const fontStyle = style.fontStyle;
+//   const fontVariant = style.fontVariant;
+//   const fontWeight = style.fontWeight;
+//   const lineHeight = style.lineHeight;
+//   const font = [
+//     fontStyle,
+//     fontVariant,
+//     fontWeight,
+//     fontSize + "/" + lineHeight,
+//     fontStretch,
+//     fontFamily,
+//   ].join(" ");
+//   return font;
+// `;
 
-async function getFont(element: WebElement): Promise<string> {
-  const font: string = await driver.executeScript(GET_FONT, element);
-  return font;
-}
+// async function getFont(element: WebElement): Promise<string> {
+//   const font: string = await driver.executeScript(GET_FONT, element);
+//   return font;
+// }
 
-const GET_TEXT_WIDTH: string = `
-  const text = arguments[0];
-  const font = arguments[1];
-  const canvas = document.createElement("canvas");
-  const context = canvas.getContext("2d");
-  context.font = font;
-  const metrics = context.measureText(text);
-  return metrics.width;
-`;
+// const GET_TEXT_WIDTH: string = `
+//   const text = arguments[0];
+//   const font = arguments[1];
+//   const canvas = document.createElement("canvas");
+//   const context = canvas.getContext("2d");
+//   context.font = font;
+//   const metrics = context.measureText(text);
+//   return metrics.width;
+// `;
 
-async function getTextWidth(text: string, font: string): Promise<number> {
-  const textWidth: number =
-    await driver.executeScript(GET_TEXT_WIDTH, text, font);
-  return textWidth;
-}
+// async function getTextWidth(text: string, font: string): Promise<number> {
+//   const textWidth: number =
+//     await driver.executeScript(GET_TEXT_WIDTH, text, font);
+//   return textWidth;
+// }
 
 async function getHighlightedText(): Promise<string[]> {
   // ---------------------------------------------------------------------------

--- a/integ/spec/function_call1.f90.spec.ts
+++ b/integ/spec/function_call1.f90.spec.ts
@@ -232,8 +232,9 @@ async function getHighlightedText(): Promise<string[]> {
   //    highlight overlays, we return them as a list.
   // ---------------------------------------------------------------------------
   const highlights: string[] = [];
-  const font: string = await getFont(editor);
-  const charWidth: number = await getTextWidth("a", font);
+  // const font: string = await getFont(editor);
+  // const charWidth: number = await getTextWidth("a", font);
+  const charWidth: number = 6;  // hardcoded for Github Actions
   const overlays: WebElement[] =
     await driver.wait<WebElement[]>(
       until.elementsLocated(

--- a/integ/spec/function_call1.f90.spec.ts
+++ b/integ/spec/function_call1.f90.spec.ts
@@ -450,7 +450,7 @@ describe(fileName, () => {
       ];
       try {
         assert.deepEqual(labels, superset);
-      } catch (error: any) {
+      } catch {
         console.warn("Failed to exact-match against the suggestion list, checking if the results are a subset of the expected suggestions (such as if the window resolution is too small to display the entire list).")
         superset = new Set<string>(superset);
         assert.isTrue(

--- a/integ/spec/function_call1.f90.spec.ts
+++ b/integ/spec/function_call1.f90.spec.ts
@@ -293,7 +293,7 @@ before(async () => {
   await lfortranPathSetting.setValue("./lfortran/src/bin/lfortran");
   const fontFamily: Setting =
     await settingsEditor.findSettingByID("editor.fontFamily");
-  await fontFamily.setValue("monospace");
+  await fontFamily.setValue('consolas, "DejaVu Sans Mono", monospace');
   const fontSize: Setting =
     await settingsEditor.findSettingByID("editor.fontSize");
   await fontSize.setValue("10");

--- a/server/src/main.ts
+++ b/server/src/main.ts
@@ -35,6 +35,7 @@ connection.onCompletion(server.onCompletion.bind(server));
 connection.onCompletionResolve(server.onCompletionResolve.bind(server));
 connection.onHover(server.onHover.bind(server));
 connection.onRenameRequest(server.onRenameRequest.bind(server));
+connection.onDocumentHighlight(server.onDocumentHighlight.bind(server));
 
 documents.onDidClose(server.onDidClose.bind(server));
 documents.onDidChangeContent(server.onDidChangeContent.bind(server));

--- a/server/test/spec/lfortran-language-server.spec.ts
+++ b/server/test/spec/lfortran-language-server.spec.ts
@@ -8,6 +8,8 @@ import {
   Diagnostic,
   DiagnosticSeverity,
   DidChangeConfigurationParams,
+  DocumentHighlight,
+  DocumentHighlightParams,
   DocumentSymbolParams,
   Hover,
   HoverParams,
@@ -888,6 +890,79 @@ describe("LFortranLanguageServer", () => {
       const text: string = "foo bar baz qux";
       document.getText.returns(text);
 
+      const symbols: SymbolInformation[] = [
+        {
+          name: "foo",
+          kind: SymbolInformation.Function,
+          location: {
+            uri: uri,
+            range: {
+              start: {
+                line: 0,
+                character: 0,
+              },
+              end: {
+                line: 0,
+                character: 3,
+              },
+            },
+          },
+        },
+        {
+          name: "bar",
+          kind: SymbolInformation.Function,
+          location: {
+            uri: uri,
+            range: {
+              start: {
+                line: 0,
+                character: 4,
+              },
+              end: {
+                line: 0,
+                character: 7,
+              },
+            },
+          },
+        },
+        {
+          name: "baz",
+          kind: SymbolInformation.Function,
+          location: {
+            uri: uri,
+            range: {
+              start: {
+                line: 0,
+                character: 8,
+              },
+              end: {
+                line: 0,
+                character: 11,
+              },
+            },
+          },
+        },
+        {
+          name: "qux",
+          kind: SymbolInformation.Function,
+          location: {
+            uri: uri,
+            range: {
+              start: {
+                line: 0,
+                character: 12,
+              },
+              end: {
+                line: 0,
+                character: 15,
+              },
+            },
+          },
+        },
+      ];
+
+      server.index(uri, symbols);
+
       const newName: string = "quo";
 
       const expected: WorkspaceEdit = {
@@ -920,6 +995,124 @@ describe("LFortranLanguageServer", () => {
       };
 
       const actual: WorkspaceEdit = await server.onRenameRequest(params);
+      assert.deepEqual(actual, expected);
+    });
+  });
+
+  describe("onDocumentHighlight", () => {
+    it("does not highlight symbols when they are not recognized", async () => {
+      const text: string = "foo bar foo baz.foo";
+      document.getText.returns(text);
+
+      const symbols: SymbolInformation[] = [
+        {
+          name: "foo",
+          kind: SymbolInformation.Function,
+          location: {
+            uri: uri,
+            range: {
+              start: {
+                line: 0,
+                character: 0,
+              },
+              end: {
+                line: 0,
+                character: 3,
+              },
+            },
+          },
+        },
+      ];
+
+      server.index(uri, symbols);
+
+      const params: DocumentHighlightParams = {
+        textDocument: document,
+        position: {
+          line: 0,
+          character: 4,
+        },
+      };
+
+      const actual: DocumentHighlight[] | undefined | null = await server.onDocumentHighlight(params);
+      assert.isUndefined(actual);
+    });
+
+    it("highlights symbols when they are recognized", async () => {
+      const text: string = "foo bar foo baz.foo";
+      document.getText.returns(text);
+
+      const symbols: SymbolInformation[] = [
+        {
+          name: "foo",
+          kind: SymbolInformation.Function,
+          location: {
+            uri: uri,
+            range: {
+              start: {
+                line: 0,
+                character: 0,
+              },
+              end: {
+                line: 0,
+                character: 3,
+              },
+            },
+          },
+        },
+      ];
+
+      server.index(uri, symbols);
+
+      const expected: DocumentHighlight[] = [
+        {
+          range: {
+            start: {
+              line: 0,
+              character: 0,
+            },
+            end: {
+              line: 0,
+              character: 3,
+            },
+          },
+        },
+        {
+          range: {
+            start: {
+              line: 0,
+              character: 8,
+            },
+            end: {
+              line: 0,
+              character: 11,
+            },
+          },
+        },
+        {
+          range: {
+            start: {
+              line: 0,
+              character: 16,
+            },
+            end: {
+              line: 0,
+              character: 19,
+            },
+          },
+        },
+      ];
+
+      const params: DocumentHighlightParams = {
+        textDocument: document,
+        position: {
+          line: 0,
+          character: 0,
+        },
+      };
+
+      const actual: DocumentHighlight[] = await server.onDocumentHighlight(params);
+      assert.isDefined(actual);
       assert.deepEqual(actual, expected);
     });
   });


### PR DESCRIPTION
Changes:
1. Adds support for highlighting symbols (once integrated with lfortran, symbols will be highlighted contextually rather than globally).
2. Adds unit and integration tests for highlighting symbols.
3. Adds missing integration test for looking up all symbols in a document.
4. Filters the renamed and highlighted symbols by those recognized as symbols by lfortran.