### PR TITLE
Adds support for using type symbol and diagnostic types from LFortran ...

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,22 +5,21 @@
 !*/
 
 # Include specific file patterns
-!/.github/workflows/*.yaml
-!/.github/workflows/*.yml
-!/.gitignore
-!/.mocharc.json
-!/.vscodeignore
-!/README.md
 !/client/package.json
 !/client/src/*.ts
-!/client/test/spec/**/*.ts
 !/client/testFixture/*.txt
+!/client/test/spec/**/*.ts
 !/client/tsconfig.json
 !/esbuild.js
 !/eslint.config.mjs
+!/.github/workflows/*.yaml
+!/.github/workflows/*.yml
+!/.gitignore
 !/integ/spec/**/*.ts
 !/integ/tsconfig.json
+!/.mocharc.json
 !/package.json
+!/README.md
 !/scripts/*.sh
 !/server/package.json
 !/server/src/*.ts
@@ -30,7 +29,9 @@
 !/server/tsconfig.json
 !/settings.json
 !/tsconfig.json
+!/.vscodeignore
 
 # Exclude problematic file patterns
 /.test-extensions
 /lfortran
+/**/*.bak

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -20,3 +20,4 @@ versions.txt
 .vscode-test
 out/integ
 lfortran
+lfortran.bak

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -5,8 +5,19 @@ import tseslint from "typescript-eslint";
 
 /** @type {import('eslint').Linter.Config[]} */
 export default [
-  {files: ["**/*.{js,mjs,cjs,ts}"]},
-  {languageOptions: { globals: globals.browser }},
+  {
+    files: ["**/*.{js,mjs,cjs,ts}"]
+  },
+  {
+    languageOptions: {
+      globals: globals.browser
+    }
+  },
   pluginJs.configs.recommended,
   ...tseslint.configs.recommended,
+  {
+    rules: {
+      "@typescript-eslint/no-namespace": "off"
+    }
+  }
 ];

--- a/server/src/lfortran-accessors.ts
+++ b/server/src/lfortran-accessors.ts
@@ -4,20 +4,16 @@ import {
 
 import {
   Diagnostic,
-  DiagnosticSeverity,
   Location,
   Position,
   Range,
   SymbolInformation,
-  SymbolKind,
   TextEdit,
 } from 'vscode-languageserver/node';
 
 import {
-  ASRSymbolType,
   ExampleSettings,
   ErrorDiagnostics,
-  LFortranDiagnosticLevel,
 } from './lfortran-types';
 
 import which from 'which';
@@ -65,72 +61,6 @@ export interface LFortranAccessor {
                column: number,
                newName: string,
                settings: ExampleSettings): Promise<TextEdit[]>;
-}
-
-const asr_symbolType_to_lsp_SymbolKind: Map<ASRSymbolType, SymbolKind | null> = new Map([
-  [ASRSymbolType.Program, null],
-  [ASRSymbolType.Module, SymbolKind.Module],
-  [ASRSymbolType.Function, SymbolKind.Function],
-  [ASRSymbolType.GenericProcedure, SymbolKind.Function],
-  [ASRSymbolType.CustomOperator, SymbolKind.Operator],
-  [ASRSymbolType.ExternalSymbol, null],
-  [ASRSymbolType.Struct, SymbolKind.Struct],
-  [ASRSymbolType.Enum, SymbolKind.Enum],
-  [ASRSymbolType.UnionType, null],
-  [ASRSymbolType.Variable, SymbolKind.Variable],
-  [ASRSymbolType.Class, SymbolKind.Class],
-  [ASRSymbolType.ClassProcedure, SymbolKind.Method],
-  [ASRSymbolType.AssociateBlock, null],
-  [ASRSymbolType.Block, null],
-  [ASRSymbolType.Requirement, null],
-  [ASRSymbolType.Template, SymbolKind.TypeParameter],
-]);
-
-function getLspSymbolKindFromAsrSymbolType(symbolType: number): SymbolKind {
-  const symbolKind: SymbolKind | null | undefined =
-    asr_symbolType_to_lsp_SymbolKind.get(symbolType);
-
-  if (symbolKind === undefined) {
-    console.warn("Unrecognized ASR::symbolType; cannot map to LSP SymbolKind: %d", symbolType);
-    return SymbolKind.Function;
-  }
-
-  if (symbolKind === null) {
-    console.debug("No direct mapping of ASR::symbolType to LSP SymbolKind: %d", symbolType);
-    return SymbolKind.Function;
-  }
-
-  return symbolKind;
-}
-
-const lfortran_diagnostic_level_to_lsp_DiagnosticSeverity: Map<LFortranDiagnosticLevel, DiagnosticSeverity | null> = new Map([
-  [LFortranDiagnosticLevel.Error, DiagnosticSeverity.Error],
-  [LFortranDiagnosticLevel.Warning, DiagnosticSeverity.Warning],
-  [LFortranDiagnosticLevel.Note, DiagnosticSeverity.Information],
-  [LFortranDiagnosticLevel.Help, DiagnosticSeverity.Hint],
-  [LFortranDiagnosticLevel.Style, DiagnosticSeverity.Warning],
-]);
-
-function getLspDiagnosticSeverityFromLFortranDiagnosticLevel(level: number | undefined): DiagnosticSeverity {
-  if (level === undefined) {
-    console.warn("Cannot map `undefined` to LSP DiagnosticSeverity");
-    return DiagnosticSeverity.Warning;
-  }
-
-  const severity: DiagnosticSeverity | null | undefined =
-    lfortran_diagnostic_level_to_lsp_DiagnosticSeverity.get(level);
-
-  if (severity === undefined) {
-    console.warn("Unrecognized diag::Level; cannot map to LSP DiagnosticSeverity: %d", level);
-    return DiagnosticSeverity.Warning;
-  }
-
-  if (severity === null) {
-    console.debug("No direct mapping of diag::Level to LSP DiagnosticSeverity: %d", level);
-    return DiagnosticSeverity.Warning;
-  }
-
-  return severity;
 }
 
 /**
@@ -275,8 +205,6 @@ export class LFortranCLIAccessor implements LFortranAccessor {
 
         const end: Position = range.end;
         end.character--;
-
-        symbol.kind = getLspSymbolKindFromAsrSymbolType(symbol.kind);
       }
       return symbols;
     }
@@ -353,8 +281,6 @@ export class LFortranCLIAccessor implements LFortranAccessor {
           const k = Math.min(results.diagnostics.length, settings.maxNumberOfProblems);
           for (let i = 0; i < k; i++) {
             const diagnostic: Diagnostic = results.diagnostics[i];
-            diagnostic.severity =
-              getLspDiagnosticSeverityFromLFortranDiagnosticLevel(diagnostic.severity);
             diagnostic.source = "lfortran-lsp";
             diagnostic.range.start.character--;
             diagnostics.push(diagnostic);

--- a/server/src/lfortran-types.ts
+++ b/server/src/lfortran-types.ts
@@ -11,34 +11,3 @@ export interface ExampleSettings {
 export interface ErrorDiagnostics {
   diagnostics: Diagnostic[];
 }
-
-export namespace ASRSymbolType {
-  export const Program: number = 0;
-  export const Module: number = 1;
-  export const Function: number = 2;
-  export const GenericProcedure: number = 3;
-  export const CustomOperator: number = 4;
-  export const ExternalSymbol: number = 5;
-  export const Struct: number = 6;
-  export const Enum: number = 7;
-  export const UnionType: number = 8;
-  export const Variable: number = 9;
-  export const Class: number = 10;
-  export const ClassProcedure: number = 11;
-  export const AssociateBlock: number = 12;
-  export const Block: number = 13;
-  export const Requirement: number = 14;
-  export const Template: number = 15;
-}
-
-export type ASRSymbolType = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 14 | 15;
-
-export namespace LFortranDiagnosticLevel {
-  export const Error: number = 0;
-  export const Warning: number = 1;
-  export const Note: number = 2;
-  export const Help: number = 3;
-  export const Style: number = 4;
-}
-
-export type LFortranDiagnosticLevel = 0 | 1 | 2 | 3 | 4;

--- a/server/src/lfortran-types.ts
+++ b/server/src/lfortran-types.ts
@@ -11,3 +11,34 @@ export interface ExampleSettings {
 export interface ErrorDiagnostics {
   diagnostics: Diagnostic[];
 }
+
+export namespace ASRSymbolType {
+  export const Program: number = 0;
+  export const Module: number = 1;
+  export const Function: number = 2;
+  export const GenericProcedure: number = 3;
+  export const CustomOperator: number = 4;
+  export const ExternalSymbol: number = 5;
+  export const Struct: number = 6;
+  export const Enum: number = 7;
+  export const UnionType: number = 8;
+  export const Variable: number = 9;
+  export const Class: number = 10;
+  export const ClassProcedure: number = 11;
+  export const AssociateBlock: number = 12;
+  export const Block: number = 13;
+  export const Requirement: number = 14;
+  export const Template: number = 15;
+}
+
+export type ASRSymbolType = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 14 | 15;
+
+export namespace LFortranDiagnosticLevel {
+  export const Error: number = 0;
+  export const Warning: number = 1;
+  export const Note: number = 2;
+  export const Help: number = 3;
+  export const Style: number = 4;
+}
+
+export type LFortranDiagnosticLevel = 0 | 1 | 2 | 3 | 4;

--- a/server/test/spec/lfortran-accessors.spec.ts
+++ b/server/test/spec/lfortran-accessors.spec.ts
@@ -12,6 +12,8 @@ import { LFortranCLIAccessor } from "../../src/lfortran-accessors";
 
 import { settings } from "./lfortran-common";
 
+import { LFortranDiagnosticLevel } from '../../src/lfortran-types';
+
 import { assert } from "chai";
 
 import "mocha";
@@ -244,7 +246,38 @@ describe("LFortranCLIAccessor", () => {
       ];
 
       const stdout = JSON.stringify({
-        diagnostics: expected
+        diagnostics: [
+          {
+            range: {
+              start: {
+                line: 0,
+                character: 10
+              },
+              end: {
+                line: 2,
+                character: 20
+              }
+            },
+            severity: LFortranDiagnosticLevel.Warning,
+            source: "lfortran-lsp",
+            message: "foo should be bar"
+          },
+          {
+            range: {
+              start: {
+                line: 5,
+                character: 13
+              },
+              end: {
+                line: 5,
+                character: 17
+              }
+            },
+            severity: LFortranDiagnosticLevel.Warning,
+            source: "lfortran-lsp",
+            message: "baz should be qux"
+          },
+        ]
       });
 
       sinon.stub(lfortran, "runCompiler").resolves(stdout);

--- a/server/test/spec/lfortran-accessors.spec.ts
+++ b/server/test/spec/lfortran-accessors.spec.ts
@@ -216,7 +216,7 @@ describe("LFortranCLIAccessor", () => {
           range: {
             start: {
               line: 0,
-              character: 10
+              character: 9
             },
             end: {
               line: 2,
@@ -231,7 +231,7 @@ describe("LFortranCLIAccessor", () => {
           range: {
             start: {
               line: 5,
-              character: 13
+              character: 12
             },
             end: {
               line: 5,

--- a/server/test/spec/lfortran-accessors.spec.ts
+++ b/server/test/spec/lfortran-accessors.spec.ts
@@ -12,8 +12,6 @@ import { LFortranCLIAccessor } from "../../src/lfortran-accessors";
 
 import { settings } from "./lfortran-common";
 
-import { LFortranDiagnosticLevel } from '../../src/lfortran-types';
-
 import { assert } from "chai";
 
 import "mocha";
@@ -258,7 +256,7 @@ describe("LFortranCLIAccessor", () => {
                 character: 20
               }
             },
-            severity: LFortranDiagnosticLevel.Warning,
+            severity: DiagnosticSeverity.Warning,
             source: "lfortran-lsp",
             message: "foo should be bar"
           },
@@ -273,7 +271,7 @@ describe("LFortranCLIAccessor", () => {
                 character: 17
               }
             },
-            severity: LFortranDiagnosticLevel.Warning,
+            severity: DiagnosticSeverity.Warning,
             source: "lfortran-lsp",
             message: "baz should be qux"
           },

--- a/server/test/spec/lfortran-language-server.spec.ts
+++ b/server/test/spec/lfortran-language-server.spec.ts
@@ -290,7 +290,7 @@ describe("LFortranLanguageServer", () => {
           range: {
             start: {
               line: 0,
-              character: 10
+              character: 9
             },
             end: {
               line: 2,
@@ -305,7 +305,7 @@ describe("LFortranLanguageServer", () => {
           range: {
             start: {
               line: 5,
-              character: 13
+              character: 12
             },
             end: {
               line: 5,

--- a/server/test/spec/lfortran-language-server.spec.ts
+++ b/server/test/spec/lfortran-language-server.spec.ts
@@ -33,7 +33,6 @@ import { TextDocument } from "vscode-languageserver-textdocument";
 
 import {
   ExampleSettings,
-  LFortranDiagnosticLevel,
 } from '../../src/lfortran-types';
 
 import { LFortranCLIAccessor } from "../../src/lfortran-accessors";
@@ -332,7 +331,7 @@ describe("LFortranLanguageServer", () => {
                 character: 20
               }
             },
-            severity: LFortranDiagnosticLevel.Warning,
+            severity: DiagnosticSeverity.Warning,
             source: "lfortran-lsp",
             message: "foo should be bar"
           },
@@ -348,7 +347,7 @@ describe("LFortranLanguageServer", () => {
               }
             },
             // NOTE: Right now, the severity is hard-coded to Warning ...
-            severity: LFortranDiagnosticLevel.Warning,
+            severity: DiagnosticSeverity.Warning,
             source: "lfortran-lsp",
             message: "baz should be qux"
           },

--- a/server/test/spec/lfortran-language-server.spec.ts
+++ b/server/test/spec/lfortran-language-server.spec.ts
@@ -31,7 +31,10 @@ import {
 
 import { TextDocument } from "vscode-languageserver-textdocument";
 
-import { ExampleSettings } from '../../src/lfortran-types';
+import {
+  ExampleSettings,
+  LFortranDiagnosticLevel,
+} from '../../src/lfortran-types';
 
 import { LFortranCLIAccessor } from "../../src/lfortran-accessors";
 
@@ -317,7 +320,39 @@ describe("LFortranLanguageServer", () => {
       ];
 
       const stdout = JSON.stringify({
-        diagnostics: diagnostics
+        diagnostics: [
+          {
+            range: {
+              start: {
+                line: 0,
+                character: 10
+              },
+              end: {
+                line: 2,
+                character: 20
+              }
+            },
+            severity: LFortranDiagnosticLevel.Warning,
+            source: "lfortran-lsp",
+            message: "foo should be bar"
+          },
+          {
+            range: {
+              start: {
+                line: 5,
+                character: 13
+              },
+              end: {
+                line: 5,
+                character: 17
+              }
+            },
+            // NOTE: Right now, the severity is hard-coded to Warning ...
+            severity: LFortranDiagnosticLevel.Warning,
+            source: "lfortran-lsp",
+            message: "baz should be qux"
+          },
+        ]
       });
       sinon.stub(lfortran, "runCompiler").resolves(stdout);
       document.getText.returns("");


### PR DESCRIPTION
... rather than hardcoding them.

These changes address their respective TODOs in https://github.com/lfortran/lfortran-lsp/issues/6. The error types were already returned by LFortran for diagnostics but we had hardcoded them to `DiagnosticSeverity.Warning`.

Depends on: https://github.com/lfortran/lfortran/pull/5585

Minor fixes:
- Fixes the bug that caused the reported diagnostic starting location to be off by one character.