### PR TITLE
enh: use continue compilation with show document symbols

### DIFF
--- a/server/src/lfortran-accessors.ts
+++ b/server/src/lfortran-accessors.ts
@@ -281,7 +281,7 @@ export class LFortranCLIAccessor implements LFortranAccessor {
     const fnid: string = "showDocumentSymbols(...)";
     const start: number = performance.now();
 
-    const flags = ["--show-document-symbols"];
+    const flags = ["--show-document-symbols", "--continue-compilation"];
     const stdout = await this.runCompiler(settings, flags, text, "[]");
 
     let symbols: SymbolInformation[];


### PR DESCRIPTION
Fixes #21

Before

<img width="724" alt="image" src="https://github.com/user-attachments/assets/9c0d07dc-866d-47a5-b0b6-2d0eaa76f157" />

After changing `x` to `xxq`


<img width="750" alt="image" src="https://github.com/user-attachments/assets/8521f016-9618-4185-82c2-7a94e78415f1" />

```console
% lfortran examples/expr2.f90 --show-document-symbols --continue-compilation | jq
[
  {
    "kind": 12,
    "location": {
      "range": {
        "start": {
          "character": 1,
          "line": 0
        },
        "end": {
          "character": 11,
          "line": 8
        }
      },
      "uri": "uri"
    },
    "name": "expr2"
  },
  {
    "kind": 13,
    "location": {
      "range": {
        "start": {
          "character": 12,
          "line": 3
        },
        "end": {
          "character": 12,
          "line": 3
        }
      },
      "uri": "uri"
    },
    "name": "x"
  }
]
```