### PR TITLE
Fixes infinite loop while extracting definitions from invalid ranges

### DIFF
--- a/server/src/bug-report-provider.ts
+++ b/server/src/bug-report-provider.ts
@@ -1,14 +1,183 @@
 import {
   Diagnostic,
+  Location,
+  Position,
+  Range,
   RenameParams,
   WorkspaceEdit,
 } from 'vscode-languageserver/node';
 
-import { LFortranSettings } from './lfortran-types';
-
 export interface BugReportProvider {
   getTitle(): string;
   getBody(params: object): string;
+}
+
+interface LineColStats {
+  numLines: number;
+  minNumCols: number;
+  meanNumCols: number;
+  stdDevNumCols: number;
+  medianNumCols: number;
+  maxNumCols: number;
+  lineCols: number[];
+}
+
+function getLineColStats(text: string): LineColStats {
+  const lineCols: number[] = [];
+  let minNumCols: number = Number.MAX_SAFE_INTEGER;
+  let maxNumCols: number = 0;
+  let meanNumCols: number = 0.0;
+  let stdDevNumCols: number = 0.0;
+  let medianNumCols: number = 0.0;
+
+  let line = 0;
+  let col = 0;
+  for (let i = 0, k = text.length; i < k; i++) {
+    const c: string = text[i];
+    switch (c) {
+      case '\r': {
+        if (((i + 1) < k) && (text[i + 1] === '\n')) {
+          i++;
+        }
+        // fallthrough
+      }
+      case '\n': {
+        lineCols.push(col + 1);
+
+        line++;
+        col = 0;
+        break;
+      }
+      default: {
+        col++;
+      }
+    }
+  }
+
+  lineCols.push(col + 1);
+
+  const numLines: number = line + 1;
+  const sortedLineCols = [...lineCols];
+  sortedLineCols.sort((a, b) => a - b);
+
+  if ((sortedLineCols.length % 2) == 0) {
+    const i: number = sortedLineCols.length / 2;
+    const leftNumCols: number = sortedLineCols[i];
+    const rightNumCols: number = sortedLineCols[i - 1];
+    medianNumCols = (leftNumCols + rightNumCols) / 2.0;
+  } else {
+    const i: number = (sortedLineCols.length - 1) / 2;
+    medianNumCols = sortedLineCols[i];
+  }
+
+  let sumNumCols: number = 0;
+  for (let i = 0, k = sortedLineCols.length; i < k; i++) {
+    const numCols: number = sortedLineCols[i];
+    sumNumCols += numCols;
+    if (numCols < minNumCols) {
+      minNumCols = numCols;
+    }
+    if (numCols > maxNumCols) {
+      maxNumCols = numCols;
+    }
+  }
+
+  meanNumCols = sumNumCols / numLines;
+
+  let varNumCols = 0.0;
+  for (let i = 0, k = sortedLineCols.length; i < k; i++) {
+    const numCols: number = sortedLineCols[i];
+    const errNumCols: number = numCols - meanNumCols;
+    varNumCols += (errNumCols * errNumCols);
+  }
+  varNumCols /= numLines;
+  stdDevNumCols = Math.sqrt(varNumCols);
+
+  return {
+    numLines: numLines,
+    minNumCols: minNumCols,
+    meanNumCols: meanNumCols,
+    stdDevNumCols: stdDevNumCols,
+    medianNumCols: medianNumCols,
+    maxNumCols: maxNumCols,
+    lineCols: lineCols,
+  };
+}
+
+export class ExtractDefinitionBugReportProvider implements BugReportProvider {
+  public location: Location;
+  public text: string;
+
+  constructor(location: Location, text: string) {
+    this.location = location;
+    this.text = text;
+  }
+
+  getTitle(): string {
+    return "[Generated] LFortranLanguageServer.extractDefinition received invalid location data."
+  }
+
+  getBody({ version }: {
+    version: string,
+  }): string {
+    const range: Range = this.location.range;
+
+    const start: Position = range.start;
+    const startLine: number = start.line;
+    const startCol: number = start.character;
+
+    const end: Position = range.end;
+    const endLine: number = end.line;
+    const endCol: number = end.character;
+
+    const stats: LineColStats = getLineColStats(this.text);
+
+    let message: string;
+
+    if (startLine >= stats.numLines) {
+      message = `The starting line [${startLine}] in the location data was outside the bounds of the number of available lines [${stats.numLines}].`;
+    } else if (endLine >= stats.numLines) {
+      message = `The ending line [${endLine}] in the location data was outside the bounds of the number of available lines [${stats.numLines}].`;
+    } else if (startCol >= stats.lineCols[startLine]) {
+      message = `The starting column [${startCol}] was greater than the maximum column [${stats.lineCols[startLine]}] on line [${startLine}].`;
+    } else if (endCol >= stats.lineCols[endLine]) {
+      message = `The ending column [${endCol}] was greater than the maximum column [${stats.lineCols[endLine]}] on line [${endLine}].`;
+    } else {
+      message = "An unexpected error occurred, please investigate."
+    }
+
+    return `
+${message}
+
+### Text
+
+\`\`\`fortran
+${this.text}
+\`\`\`
+
+### Location Data
+
+\`\`\`json
+${JSON.stringify(this.location, undefined, 2)}
+\`\`\`
+
+### Line and Column Statistics
+
+\`\`\`json
+${JSON.stringify(stats, undefined, 2)}
+\`\`\`
+
+### LFortran Version
+
+\`\`\`shell
+${version}
+\`\`\`
+
+### Additional Information
+
+If you can provide additional information about what you were doing or how to reproduce this error, please include it here.
+`.trim();
+  }
 }
 
 export class RenameSymbolBugReportProvider implements BugReportProvider {
@@ -27,7 +196,7 @@ export class RenameSymbolBugReportProvider implements BugReportProvider {
   }
 
   getBody({ version, outputText, diagnostics }: {
-    version: LFortranSettings,
+    version: string,
     outputText: string,
     diagnostics: Diagnostic[]
   }): string {
@@ -69,6 +238,10 @@ ${JSON.stringify(diagnostics, undefined, 2)}
 \`\`\`shell
 ${version}
 \`\`\`
+
+### Additional Information
+
+If you can provide additional information about what you were doing or how to reproduce this error, please include it here.
 `.trim();
   }
 }

--- a/server/src/logger.ts
+++ b/server/src/logger.ts
@@ -24,6 +24,23 @@ export function logLevelFromName(lowerName: string): LogLevel {
   return level;
 }
 
+interface Type {
+  new(...args: any[]): any;
+}
+
+export function makeLoggable(kind: Type): Type {
+  const context: string = kind.name;
+  kind.prototype.logFatal = function (...args: any[]) { this.logger.fatal(context, ...args); }
+  kind.prototype.logError = function (...args: any[]) { this.logger.error(context, ...args); }
+  kind.prototype.logWarn = function (...args: any[]) { this.logger.warn(context, ...args); }
+  kind.prototype.logInfo = function (...args: any[]) { this.logger.info(context, ...args); }
+  kind.prototype.logDebug = function (...args: any[]) { this.logger.debug(context, ...args); }
+  kind.prototype.logTrace = function (...args: any[]) { this.logger.trace(context, ...args); }
+  kind.prototype.logBenchmark = function (...args: any[]) { this.logger.benchmark(context, ...args); }
+  kind.prototype.logBenchmarkAndTrace = function (...args: any[]) { this.logger.benchmarkAndTrace(context, ...args); }
+  return kind;
+}
+
 export class Logger {
 
   /** Current `LogLevel` for filtering and formatting messages. */

--- a/server/test/spec/lfortran-accessors.spec.ts
+++ b/server/test/spec/lfortran-accessors.spec.ts
@@ -3,7 +3,6 @@ import {
   Diagnostic,
   DiagnosticSeverity,
   Range,
-  SymbolInformation,
   SymbolKind,
   TextEdit,
 } from "vscode-languageserver/node";
@@ -61,11 +60,51 @@ describe("LFortranCLIAccessor", () => {
     });
 
     it("returns the expected symbol information", async () => {
-      const response: SymbolInformation[] = [
+      const response: Record<string, any>[] = [
         {
           name: "foo",
-          // NOTE: Right now, the kind is hard-coded to Function ...
           kind: SymbolKind.Function,
+          filename: uri,
+          location: {
+            uri: "uri",
+            range: {
+              start: {
+                line: 0,
+                character: 1
+              },
+              end: {
+                line: 0,
+                character: 5
+              }
+            }
+          }
+        },
+        {
+          name: "bar",
+          kind: SymbolKind.Function,
+          filename: uri,
+          location: {
+            uri: "uri",
+            range: {
+              start: {
+                line: 3,
+                character: 15
+              },
+              end: {
+                line: 3,
+                character: 25
+              }
+            }
+          }
+        },
+      ];
+      const stdout = JSON.stringify(response);
+      sinon.stub(lfortran, "runCompiler").resolves(stdout);
+      const expected: Record<string, any>[] = [
+        {
+          name: "foo",
+          kind: SymbolKind.Function,
+          filename: uri,
           location: {
             uri: uri,
             range: {
@@ -82,8 +121,8 @@ describe("LFortranCLIAccessor", () => {
         },
         {
           name: "bar",
-          // NOTE: Right now, the kind is hard-coded to Function ...
           kind: SymbolKind.Function,
+          filename: uri,
           location: {
             uri: uri,
             range: {
@@ -99,9 +138,6 @@ describe("LFortranCLIAccessor", () => {
           }
         },
       ];
-      const stdout = JSON.stringify(response);
-      sinon.stub(lfortran, "runCompiler").resolves(stdout);
-      const expected = response;
       for (const symbol of expected) {
         const range = symbol.location.range;
         range.start.character--;


### PR DESCRIPTION
Changes:
- Fixes infinite loop while extracting definitions from invalid character ranges
- Adds support for external document symbols
- Simplifies the logging mechanism by capturing the log context within a closure
- Adds bug reporting mechanism to capture when the character ranges are out-of-bounds while extracting definitions

Addresses #50 